### PR TITLE
Misc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The idea is to build the kernel as a `no_std` longmode executable and then build
 You need a nightly [Rust](https://www.rust-lang.org) compiler, [xargo](https://github.com/japaric/xargo), [objcopy](https://sourceware.org/binutils/docs/binutils/objcopy.html) (or a similar tool), and [QEMU](https://www.qemu.org/) (for running it).
 
 ```
-> RUST_TARGET_PATH=(pwd) xargo build --target test
-> objcopy -O binary -S target/test/debug/elf_loader test-bin
-> qemu-system-x86_64 -hda test-bin -d int -s
+> RUST_TARGET_PATH=$(pwd) xargo build --target x86_64-bootloader --release
+> objcopy -O binary -S target/x86_64-bootloader/release/bootloader bootimage.bin
+> qemu-system-x86_64 -hda bootimage.bin -d int -s
 ```

--- a/x86_64-bootloader.json
+++ b/x86_64-bootloader.json
@@ -4,7 +4,9 @@
     "linker-flavor": "ld",
     "linker": "ld.bfd",
     "pre-link-args": {
-        "ld": ["-Tlinker.ld"]
+        "ld": [
+	    "--script=linker.ld"
+	]
     },
     "target-endian": "little",
     "target-pointer-width": "64",


### PR DESCRIPTION
Hi phil,

small PR here:

- Fixes pwd command substitution in README
- Fixes target file name in README
- Makes the target json a bit more intuitive to read by using long option argument for the linker. The short one can be confusing if you have no experience with `ld`.

By the way, I tried if switching to `lld` is straight-forward, but it throws an error if you just exchange the linker flavor:

```bash
error: linking with `lld` failed: exit code: 1
  |
  = note: "lld" "-flavor" "gnu" "--script=linker.ld" "-L" "/home/arichter/.xargo/lib/rustlib/x86_64-bootloader/lib" "/home/arichter/repos/bootloader/target/x86_64-bootloader/release/deps/bootloader-484e5291b10a3861.bootloader0.rcgu.o" "-o" "/home/arichter/repos/bootloader/target/x86_64-bootloader/release/deps/bootloader-484e5291b10a3861" "--gc-sections" "-L" "/home/arichter/repos/bootloader/target/x86_64-bootloader/release/deps" "-L" "/home/arichter/repos/bootloader/target/release/deps" "-L" "/home/arichter/.xargo/lib/rustlib/x86_64-bootloader/lib" "-Bstatic" "/home/arichter/repos/bootloader/target/x86_64-bootloader/release/deps/librlibc-d40895cb3b906a9b.rlib" "-Bdynamic"
  = note: lld: error: bootloader0-5c45d0f13b04536f6388a70c7a9344c0.rs:(.second_stage+0xA5): unrecognized reloc 13
          lld: error: bootloader0-5c45d0f13b04536f6388a70c7a9344c0.rs:(.second_stage+0x1A2): unrecognized reloc 13
          lld: error: bootloader0-5c45d0f13b04536f6388a70c7a9344c0.rs:(.second_stage+0x1CC): unrecognized reloc 13
          lld: error: bootloader0-5c45d0f13b04536f6388a70c7a9344c0.rs:(.second_stage+0x1F9): unrecognized reloc 13
```

