### PR TITLE
Set Target Operating Mode

### DIFF
--- a/src/second_stage.s
+++ b/src/second_stage.s
@@ -10,6 +10,18 @@ second_stage:
     lea si, second_stage_start_str
     call println
 
+set_target_operating_mode:
+    # Some BIOSs assume the processor will only operate in Legacy Mode. We change the Target
+    # Operating Mode to "Long Mode Target Only", so the firmware expects each CPU to enter Long Mode
+    # once and then stay in it. This allows the firmware to enable mode-specifc optimizations.
+    # We save the flags, because CF is set if the callback is not supported (in which case, this is
+    # a NOP)
+    pushf
+    mov ax, 0xec00
+    mov bl, 0x2
+    int 0x15
+    popf
+
 load_kernel_from_disk:
     # start of memory buffer
     lea eax, _kernel_buffer


### PR DESCRIPTION
This sets the Target Operating Mode in the second stage before we enter Long Mode. This tells the firmware that we are only planning to operate in 64-bit mode and will not switch back to Legacy Mode, allowing it to make optimisations that it otherwise wouldn't be able to make safely.

Afaict, this was first implemented by AMD for the Opteron in ~2003, and is documented in section 12.21 of [this document](http://developer.amd.com/wordpress/media/2012/10/26094.pdf). Other docs are sparse, but it should be a nop on processors that don't support the function, and this should handle the error codes correctly (it sets the carry flag if the function is not supported).

While the docs only specify that it allows the BIOS to make optimizations that are not visible to system software, the default mode only allows the processor to run in Legacy Mode, and so I wonder if any firmwares that have SMM bugs in x86_64 mode may be fixed by this - that is just postulation tho

Edit: Travis failure is not related - merging #17 should fix this build as well