### PR TITLE
Add more explanations to some opaque x86 instructions

### DIFF
--- a/src/boot.s
+++ b/src/boot.s
@@ -12,7 +12,8 @@ _start:
     mov fs, ax
     mov gs, ax
 
-    # TODO explain
+    # clear the direction flag (e.g. go forward in memory when using
+    # instructions like lodsb)
     cld
 
 
@@ -29,6 +30,7 @@ enable_a20:
     out 0x92, al
 
 enter_protected_mode:
+    # clear interrupts
     cli
     push ds
     push es
@@ -118,6 +120,9 @@ println:
 print:
     cld
 print_loop:
+    # note: if direction flag is set (via std)
+    # this will DECREMENT the ptr, effectively
+    # reading/printing in reverse.
     lodsb al, BYTE PTR [esi]
     test al, al
     jz print_done

--- a/src/second_stage.s
+++ b/src/second_stage.s
@@ -56,7 +56,11 @@ load_next_kernel_block_from_disk:
     push ecx
     push esi
     mov ecx, 512 / 4
+    # move with zero extension
+    # because we are moving a word ptr
+    # to esi, a 32-bit register.
     movzx esi, word ptr [dap_buffer_addr]
+    # move from esi to edi ecx times.
     rep movsd [edi], [esi]
     pop esi
     pop ecx
@@ -256,7 +260,7 @@ gdt_64_pointer:
 
 long_mode:
     # call load_elf with kernel start address, size, and memory map as arguments
-    movabs rdi, 0x400000
+    movabs rdi, 0x400000 # move absolute 64-bit to register
     mov rsi, _kib_kernel_size
     lea rdx, _memory_map
     movzx rcx, word ptr mmap_ent


### PR DESCRIPTION
Usually the reader will have to search for the definitions of the instructions. By including the (short) description, they can continue to go through the code without needing to do a search.