### PR TITLE
Version 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bootloader"
-version = "0.2.0-alpha-005"
+version = "0.2.0-beta"
 dependencies = [
  "fixedvec 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "os_bootinfo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["publish-lockfile"]
 
 [package]
 name = "bootloader"
-version = "0.2.0-alpha-005"
+version = "0.2.0-beta"
 authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 license = "MIT/Apache-2.0"
 description = "An experimental pure-Rust x86 bootloader."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,23 @@
 #![no_std]
 
 pub extern crate os_bootinfo as bootinfo;
+
+/// Defines the entry point function.
+///
+/// The function must have the signature `fn(&'static BootInfo) -> !`.
+///
+/// This macro just creates a function named `_start`, which the linker will use as the entry
+/// point. The advantage of using this macro instead of providing an own `_start` function is
+/// that the macro ensures that the function and argument types are correct.
+#[macro_export]
+macro_rules! entry_point {
+    ($path:path) => {
+        #[export_name = "_start"]
+        pub extern "C" fn __impl_start(boot_info: &'static $crate::bootinfo::BootInfo) -> ! {
+            // validate the signature of the program entry point
+            let f: fn(&'static $crate::bootinfo::BootInfo) -> ! = $path;
+
+            f(boot_info)
+        }
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
 #![no_std]
 
-pub extern crate os_bootinfo as bootinfo;
+extern crate os_bootinfo;
+
+pub mod bootinfo {
+    pub use os_bootinfo::*;
+}
 
 /// Defines the entry point function.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+#![no_std]
+
+pub extern crate os_bootinfo as bootinfo;

--- a/src/second_stage.s
+++ b/src/second_stage.s
@@ -81,13 +81,7 @@ check_cpu:
     call check_cpuid
     call check_long_mode
 
-disable_irqs:
-    mov al, 0xFF     # Out 0xFF to 0xA1 and 0x21 to disable all IRQs.
-    out 0xA1, al
-    out 0x21, al
-
-    nop
-    nop
+    cli                   # disable interrupts
 
     lidt zero_idt         # Load a zero length IDT so that any NMI causes a triple fault.
 


### PR DESCRIPTION
Given that we were in alpha state for a long time and there were no real bugs reported, I think it's time to finally release version 0.2.0. Another big reason for doing it is that the current versions of bootimage only work with the latest alpha versions, so everybody was forced to use the alpha versions anyway.

There are a few improvements in this PR:

<ul>
<li> Add a `lib.rs` that re-exports the `os_bootinfo` crate as `bootinfo`. This works nicely with the [new version of `bootimage`](https://github.com/rust-osdev/bootimage/pull/16). It means that you no longer need to add a `os_bootinfo` dependency and instead add the `bootloader` as dependency directly. This solves the potential version mismatch problem (i.e. kernel and bootloader use different `os_bootinfo` versions).</li>
<li>Add an `entry_point` macro which allows to specify the entry point like this:

```rust
#[macro_use]
extern crate bootloader;

#[cfg(not(test))]
entry_point!(kernel_main);

fn kernel_main(boot_info: &'static bootloader::bootinfo::BootInfo) -> ! {…}
```

The advantage of using this macro is that the function signature is type-checked, i.e. it is an error if the argument type is wrong. You also no longer need `no_mangle`, `extern "C"`, etc since the macro handles this for us.
</li>
<li>
- Disable interrupts instead of masking them. This solves #14.
</li>
</ul>

This PR is **already pulished as `0.2.0-beta`**. Please test it and give feedback!