### PR TITLE
Make printing from the bootloader cleaner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ version = "0.2.0-beta"
 dependencies = [
  "fixedvec 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "os_bootinfo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "usize_conversions 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "x86_64 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "xmas-elf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -93,6 +94,11 @@ dependencies = [
  "pulldown-cmark 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "spin"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "tempdir"
@@ -175,6 +181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum skeptic 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "061203a849117b0f7090baf8157aa91dac30545208fbb85166ac58b4ca33d89c"
+"checksum spin 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14db77c5b914df6d6173dda9a3b3f5937bd802934fa5edaf934df06a3491e56f"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum usize_conversions 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f70329e2cbe45d6c97a5112daad40c34cd9a4e18edb5a2a18fefeb584d8d25e5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,8 +13,10 @@ name = "bootloader"
 version = "0.2.0-beta"
 dependencies = [
  "fixedvec 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "os_bootinfo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uart_16550 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "usize_conversions 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "x86_64 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "xmas-elf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -48,6 +50,14 @@ version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "spin 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -107,6 +117,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "uart_16550"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x86_64 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -175,6 +194,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0a7292d30132fb5424b354f5dc02512a86e4c516fe544bb7a25e7f266951b797"
+"checksum lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fb497c35d362b6a331cfd94956a07fc2c78a4604cdbee844a81170386b996dd3"
 "checksum libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b685088df2b950fccadf07a7187c8ef846a959c142338a48f9dc0b94517eb5f1"
 "checksum os_bootinfo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "66481dbeb5e773e7bd85b63cd6042c30786f834338288c5ec4f3742673db360a"
 "checksum pulldown-cmark 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8361e81576d2e02643b04950e487ec172b687180da65c731c03cf336784e6c07"
@@ -183,6 +203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum skeptic 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "061203a849117b0f7090baf8157aa91dac30545208fbb85166ac58b4ca33d89c"
 "checksum spin 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14db77c5b914df6d6173dda9a3b3f5937bd802934fa5edaf934df06a3491e56f"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+"checksum uart_16550 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "269f953d8de3226f7c065c589c7b4a3e83d10a419c7c3b5e2e0f197e6acc966e"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum usize_conversions 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f70329e2cbe45d6c97a5112daad40c34cd9a4e18edb5a2a18fefeb584d8d25e5"
 "checksum ux 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53d8df5dd8d07fedccd202de1887d94481fadaea3db70479f459e8163a1fab41"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ x86_64 = "0.2.7"
 usize_conversions = "0.2.0"
 os_bootinfo = "0.2.0"
 fixedvec = "0.2.3"
+spin = "0.4.8"
 
 [profile.dev]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,11 @@ usize_conversions = "0.2.0"
 os_bootinfo = "0.2.0"
 fixedvec = "0.2.3"
 spin = "0.4.8"
+uart_16550 = { version = "0.1.0", optional = true }
+lazy_static = { version = "1.0.2", features = ["spin_no_std"] }
+
+[features]
+serial = ["uart_16550"]
 
 [profile.dev]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,9 @@ uart_16550 = { version = "0.1.0", optional = true }
 lazy_static = { version = "1.0.2", features = ["spin_no_std"] }
 
 [features]
+default = ["vga"]
 serial = ["uart_16550"]
+vga = []
 
 [profile.dev]
 panic = "abort"

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,10 @@ extern crate xmas_elf;
 #[macro_use]
 extern crate fixedvec;
 extern crate spin;
+#[macro_use]
+extern crate lazy_static;
+#[cfg(feature = "serial")]
+extern crate uart_16550;
 
 use core::slice;
 use core::panic::PanicInfo;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ extern crate x86_64;
 extern crate xmas_elf;
 #[macro_use]
 extern crate fixedvec;
+extern crate spin;
 
 use core::slice;
 use core::panic::PanicInfo;
@@ -38,10 +39,11 @@ extern "C" {
     fn context_switch(boot_info: VirtAddr, entry_point: VirtAddr, stack_pointer: VirtAddr) -> !;
 }
 
+#[macro_use]
+mod printer;
 mod boot_info;
 mod frame_allocator;
 mod page_table;
-mod printer;
 
 pub struct IdentityMappedAddr(PhysAddr);
 
@@ -74,7 +76,7 @@ pub extern "C" fn load_elf(
     use os_bootinfo::{MemoryRegion, MemoryRegionType};
     use xmas_elf::program::{ProgramHeader, ProgramHeader64};
 
-    printer::Printer.clear_screen();
+    printer::PRINTER.lock().clear_screen();
 
     let mut memory_map = boot_info::create_from(memory_map_addr, memory_map_entry_count);
 
@@ -217,8 +219,7 @@ fn enable_write_protect_bit() {
 #[panic_implementation]
 #[no_mangle]
 pub extern "C" fn panic(info: &PanicInfo) -> ! {
-    use core::fmt::Write;
-    write!(printer::Printer, "{}", info).unwrap();
+    println!("{}", info);
     loop {}
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,8 +80,6 @@ pub extern "C" fn load_elf(
     use os_bootinfo::{MemoryRegion, MemoryRegionType};
     use xmas_elf::program::{ProgramHeader, ProgramHeader64};
 
-    printer::PRINTER.lock().clear_screen();
-
     let mut memory_map = boot_info::create_from(memory_map_addr, memory_map_entry_count);
 
     // Extract required information from the ELF file.

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1,6 +1,8 @@
 use core::fmt;
 use core::slice;
 use spin::Mutex;
+#[cfg(feature = "serial")]
+use uart_16550::SerialPort;
 
 macro_rules! println {
     () => (print!("\n"));
@@ -13,6 +15,15 @@ const BUFFER_WIDTH: usize = 80;
 const BUFFER_HEIGHT: usize = 25;
 
 pub static PRINTER: Mutex<Printer> = Mutex::new(Printer::new());
+
+#[cfg(feature = "serial")]
+lazy_static! {
+    static ref COM1: Mutex<SerialPort> = {
+        let mut serial_port = SerialPort::new(0x3f8);
+        serial_port.init();
+        Mutex::new(serial_port)
+    };
+}
 
 pub struct Printer {
     row: usize,
@@ -50,6 +61,11 @@ impl Printer {
 
 impl fmt::Write for Printer {
     fn write_str(&mut self, string: &str) -> fmt::Result {
+        let vga_buffer = self.vga_buffer();
+
+        #[cfg(feature = "serial")]
+        let mut serial_port = COM1.lock();
+
         for byte in string.bytes() {
             match byte {
                 b'\n' => {
@@ -57,13 +73,20 @@ impl fmt::Write for Printer {
                     self.column = 0;
 
                     // TODO: VGA: if we've run out of space, scroll the terminal up
+
+                    #[cfg(feature = "serial")] {
+                        serial_port.send(b'\n');
+                        serial_port.send(b'\r');
+                    }
                 }
 
                 _ => {
-                    let vga_buffer = self.vga_buffer();
                     vga_buffer[(self.row * 80 + self.column) * 2] = byte;
                     vga_buffer[(self.row * 80 + self.column) * 2 + 1] = 0xb;
                     self.column += 1;
+
+                    #[cfg(feature = "serial")]
+                    serial_port.send(byte);
                 }
             }
         }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1,96 +1,114 @@
 use core::fmt;
-use core::slice;
 use spin::Mutex;
 #[cfg(feature = "serial")]
 use uart_16550::SerialPort;
 
 macro_rules! println {
     () => (print!("\n"));
-    ($fmt: expr) => ($crate::printer::PRINTER.lock().print(format_args!(concat!($fmt, "\n"))));
-    ($fmt: expr, $($arg: tt)*) => ($crate::printer::PRINTER.lock().print(format_args!(concat!($fmt, "\n"), $($arg)*)));
+    ($fmt: expr) => (use ::core::fmt::Write; $crate::printer::PRINTER.lock().write_fmt(format_args!(concat!($fmt, "\n"))).unwrap());
+    ($fmt: expr, $($arg: tt)*) => (use ::core::fmt::Write; $crate::printer::PRINTER.lock().write_fmt(format_args!(concat!($fmt, "\n"), $($arg)*)).unwrap());
 }
 
-const VGA_BUFFER: *mut u8 = 0xb8000 as *mut _;
-const BUFFER_WIDTH: usize = 80;
-const BUFFER_HEIGHT: usize = 25;
-
-pub static PRINTER: Mutex<Printer> = Mutex::new(Printer::new());
-
-#[cfg(feature = "serial")]
 lazy_static! {
-    static ref COM1: Mutex<SerialPort> = {
-        let mut serial_port = SerialPort::new(0x3f8);
-        serial_port.init();
-        Mutex::new(serial_port)
-    };
+    pub static ref PRINTER: Mutex<Printer> = Mutex::new(Printer::new());
 }
 
 pub struct Printer {
-    row: usize,
-    column: usize,
+    #[cfg(feature = "vga")]
+    vga_buffer: VgaBuffer,
+
+    #[cfg(feature = "serial")]
+    serial_port: SerialPort,
 }
 
 impl Printer {
-    const fn new() -> Printer {
+    fn new() -> Printer {
+        #[cfg(feature = "serial")]
+        let serial_port = {
+            let mut port = SerialPort::new(0x3f8);
+            port.init();
+            port
+        };
+
         Printer {
-            row: 0,
-            column: 0,
-        }
-    }
+            #[cfg(feature = "vga")]
+            vga_buffer: VgaBuffer::new(),
 
-    pub fn clear_screen(&mut self) {
-        for byte in self.vga_buffer() {
-            *byte = 0;
-        }
-
-        self.row = 0;
-        self.column = 0;
-    }
-
-    pub fn print(&mut self, args: fmt::Arguments) {
-        use core::fmt::Write;
-        self.write_fmt(args).unwrap();
-    }
-
-    fn vga_buffer(&mut self) -> &'static mut [u8] {
-        unsafe {
-            slice::from_raw_parts_mut(VGA_BUFFER, BUFFER_WIDTH * BUFFER_HEIGHT)
+            #[cfg(feature = "serial")]
+            serial_port,
         }
     }
 }
 
 impl fmt::Write for Printer {
     fn write_str(&mut self, string: &str) -> fmt::Result {
-        let vga_buffer = self.vga_buffer();
-
-        #[cfg(feature = "serial")]
-        let mut serial_port = COM1.lock();
-
         for byte in string.bytes() {
+            #[cfg(feature = "vga")]
+            self.vga_buffer.print_byte(byte);
+
+            #[cfg(feature = "serial")]
             match byte {
                 b'\n' => {
-                    self.row += 1;
-                    self.column = 0;
-
-                    // TODO: VGA: if we've run out of space, scroll the terminal up
-
-                    #[cfg(feature = "serial")] {
-                        serial_port.send(b'\n');
-                        serial_port.send(b'\r');
-                    }
+                    self.serial_port.send(b'\n');
+                    self.serial_port.send(b'\r');
                 }
 
                 _ => {
-                    vga_buffer[(self.row * 80 + self.column) * 2] = byte;
-                    vga_buffer[(self.row * 80 + self.column) * 2 + 1] = 0xb;
-                    self.column += 1;
-
-                    #[cfg(feature = "serial")]
-                    serial_port.send(byte);
+                    self.serial_port.send(byte);
                 }
             }
         }
 
         Ok(())
+    }
+}
+
+#[cfg(feature = "vga")]
+struct VgaBuffer {
+    row: usize,
+    column: usize,
+}
+
+#[cfg(feature = "vga")]
+impl VgaBuffer {
+    pub fn new() -> VgaBuffer {
+        let mut vga = VgaBuffer {
+            row: 0,
+            column: 0,
+        };
+
+        for byte in vga.buffer() {
+            *byte = 0;
+        }
+
+        vga
+    }
+
+    fn print_byte(&mut self, byte: u8) {
+        match byte {
+            b'\n' => {
+                self.row += 1;
+                self.column = 0;
+
+                // TODO: if we've run out of space, scroll the terminal up
+            }
+
+            _ => {
+                let vga_buffer = self.buffer();
+                vga_buffer[(self.row * 80 + self.column) * 2] = byte;
+                vga_buffer[(self.row * 80 + self.column) * 2 + 1] = 0xb;
+                self.column += 1;
+            }
+        }
+    }
+
+    fn buffer(&mut self) -> &'static mut [u8] {
+        const VGA_BUFFER: *mut u8 = 0xb8000 as *mut _;
+        const BUFFER_WIDTH: usize = 80;
+        const BUFFER_HEIGHT: usize = 25;
+
+        unsafe {
+            ::core::slice::from_raw_parts_mut(VGA_BUFFER, BUFFER_WIDTH * BUFFER_HEIGHT)
+        }
     }
 }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1,35 +1,71 @@
-use core::fmt::{Result, Write};
+use core::fmt;
 use core::slice;
-use core::sync::atomic::{AtomicUsize, Ordering};
+use spin::Mutex;
+
+macro_rules! println {
+    () => (print!("\n"));
+    ($fmt: expr) => ($crate::printer::PRINTER.lock().print(format_args!(concat!($fmt, "\n"))));
+    ($fmt: expr, $($arg: tt)*) => ($crate::printer::PRINTER.lock().print(format_args!(concat!($fmt, "\n"), $($arg)*)));
+}
 
 const VGA_BUFFER: *mut u8 = 0xb8000 as *mut _;
-const SCREEN_SIZE: usize = 80 * 25;
+const BUFFER_WIDTH: usize = 80;
+const BUFFER_HEIGHT: usize = 25;
 
-pub static CURRENT_OFFSET: AtomicUsize = AtomicUsize::new(160);
+pub static PRINTER: Mutex<Printer> = Mutex::new(Printer::new());
 
-pub struct Printer;
+pub struct Printer {
+    row: usize,
+    column: usize,
+}
 
 impl Printer {
-    pub fn clear_screen(&mut self) {
-        let vga_buffer = Self::vga_buffer();
-        for byte in vga_buffer {
-            *byte = 0;
+    const fn new() -> Printer {
+        Printer {
+            row: 0,
+            column: 0,
         }
-        CURRENT_OFFSET.store(0, Ordering::Relaxed);
     }
 
-    fn vga_buffer() -> &'static mut [u8] {
-        unsafe { slice::from_raw_parts_mut(VGA_BUFFER, SCREEN_SIZE * 2) }
+    pub fn clear_screen(&mut self) {
+        for byte in self.vga_buffer() {
+            *byte = 0;
+        }
+
+        self.row = 0;
+        self.column = 0;
+    }
+
+    pub fn print(&mut self, args: fmt::Arguments) {
+        use core::fmt::Write;
+        self.write_fmt(args).unwrap();
+    }
+
+    fn vga_buffer(&mut self) -> &'static mut [u8] {
+        unsafe {
+            slice::from_raw_parts_mut(VGA_BUFFER, BUFFER_WIDTH * BUFFER_HEIGHT)
+        }
     }
 }
 
-impl Write for Printer {
-    fn write_str(&mut self, s: &str) -> Result {
-        let vga_buffer = Self::vga_buffer();
-        for byte in s.bytes() {
-            let index = CURRENT_OFFSET.fetch_add(2, Ordering::Relaxed);
-            vga_buffer[index] = byte;
-            vga_buffer[index + 1] = 0x4f;
+impl fmt::Write for Printer {
+    fn write_str(&mut self, string: &str) -> fmt::Result {
+        for byte in string.bytes() {
+            match byte {
+                b'\n' => {
+                    self.row += 1;
+                    self.column = 0;
+
+                    // TODO: VGA: if we've run out of space, scroll the terminal up
+                }
+
+                _ => {
+                    let vga_buffer = self.vga_buffer();
+                    vga_buffer[(self.row * 80 + self.column) * 2] = byte;
+                    vga_buffer[(self.row * 80 + self.column) * 2 + 1] = 0xb;
+                    self.column += 1;
+                }
+            }
         }
 
         Ok(())


### PR DESCRIPTION
I noticed that debugging from the bootloader was a bit tedious as the printer didn't allow nice formatting or handle newlines well. This PR makes the printer easier to work with and modularises it to allow printing to either the VGA buffer, the COM1 serial port, or both (configurable by features).

The configuration is mainly for future proofing (when we implement graphics mode switching, we'll want to be able to turn off the text-mode VGA printing).