### PR TITLE
Integrate os_bootinfo 0.3.0 as a submodule (with some changes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,6 @@ name = "bootloader"
 version = "0.2.1"
 dependencies = [
  "fixedvec 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "os_bootinfo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "usize_conversions 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "x86_64 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "xmas-elf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ publish-lockfile = true
 xmas-elf = "0.6.2"
 x86_64 = "0.2.7"
 usize_conversions = "0.2.0"
-os_bootinfo = "0.2.0"
 fixedvec = "0.2.3"
 
 [profile.dev]

--- a/src/boot_info.rs
+++ b/src/boot_info.rs
@@ -1,6 +1,6 @@
 use core::slice;
 
-use os_bootinfo::{E820MemoryRegion, MemoryMap, MemoryRegion, MemoryRegionType};
+use bootloader::bootinfo::{E820MemoryRegion, MemoryMap, MemoryRegion, MemoryRegionType};
 use usize_conversions::usize_from;
 use x86_64::VirtAddr;
 

--- a/src/bootinfo/memory_map.rs
+++ b/src/bootinfo/memory_map.rs
@@ -1,0 +1,208 @@
+use core::fmt;
+use core::ops::{Deref, DerefMut};
+
+const PAGE_SIZE: u64 = 4096;
+
+#[repr(C)]
+pub struct MemoryMap {
+    entries: [MemoryRegion; 32],
+    // u64 instead of usize so that the structure layout is platform
+    // independent
+    next_entry_index: u64,
+}
+
+impl MemoryMap {
+    pub fn new() -> Self {
+        MemoryMap {
+            entries: [MemoryRegion::empty(); 32],
+            next_entry_index: 0,
+        }
+    }
+
+    pub fn add_region(&mut self, region: MemoryRegion) {
+        self.entries[self.next_entry_index()] = region;
+        self.next_entry_index += 1;
+        self.sort();
+    }
+
+    pub fn sort(&mut self) {
+        use core::cmp::Ordering;
+
+        self.entries.sort_unstable_by(|r1, r2| {
+            if r1.range.is_empty() {
+                Ordering::Greater
+            } else if r2.range.is_empty() {
+                Ordering::Less
+            } else {
+                
+                let ordering = r1.range
+                    .start_frame_number
+                    .cmp(&r2.range.start_frame_number);
+                
+                if ordering == Ordering::Equal {
+                    r1.range
+                    .end_frame_number
+                    .cmp(&r2.range.end_frame_number)
+                } else {
+                    ordering   
+                }
+            }
+        });
+        if let Some(first_zero_index) = self.entries.iter().position(|r| r.range.is_empty()) {
+            self.next_entry_index = first_zero_index as u64;
+        }
+    }
+
+    fn next_entry_index(&self) -> usize {
+        self.next_entry_index as usize
+    }
+}
+
+impl Deref for MemoryMap {
+    type Target = [MemoryRegion];
+
+    fn deref(&self) -> &Self::Target {
+        &self.entries[0..self.next_entry_index()]
+    }
+}
+
+impl DerefMut for MemoryMap {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        let next_index = self.next_entry_index();
+        &mut self.entries[0..next_index]
+    }
+}
+
+impl fmt::Debug for MemoryMap {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub struct MemoryRegion {
+    pub range: FrameRange,
+    pub region_type: MemoryRegionType,
+}
+
+impl MemoryRegion {
+    pub fn empty() -> Self {
+        MemoryRegion {
+            range: FrameRange {
+                start_frame_number: 0,
+                end_frame_number: 0,
+            },
+            region_type: MemoryRegionType::Empty,
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub struct FrameRange {
+    pub start_frame_number: u64,
+    // exclusive
+    pub end_frame_number: u64,
+}
+
+impl FrameRange {
+    /// Create a new FrameRange from the passed start_addr and end_addr.
+    ///
+    /// The end_addr is exclusive.
+    pub fn new(start_addr: u64, end_addr: u64) -> Self {
+        let last_byte = end_addr - 1;
+        FrameRange {
+            start_frame_number: start_addr / PAGE_SIZE,
+            end_frame_number: (last_byte / PAGE_SIZE) + 1,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.start_frame_number == self.end_frame_number
+    }
+
+    pub fn start_addr(&self) -> u64 {
+        self.start_frame_number * PAGE_SIZE
+    }
+
+    pub fn end_addr(&self) -> u64 {
+        self.end_frame_number * PAGE_SIZE
+    }
+}
+
+impl fmt::Debug for FrameRange {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "FrameRange({:#x}..{:#x})",
+            self.start_addr(),
+            self.end_addr()
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub enum MemoryRegionType {
+    /// free RAM
+    Usable,
+    /// used RAM
+    InUse,
+    /// unusable
+    Reserved,
+    /// ACPI reclaimable memory
+    AcpiReclaimable,
+    /// ACPI NVS memory
+    AcpiNvs,
+    /// Area containing bad memory
+    BadMemory,
+    /// kernel memory
+    Kernel,
+    /// kernel stack memory
+    KernelStack,
+    /// memory used by page tables
+    PageTable,
+    /// memory used by the bootloader
+    Bootloader,
+    /// frame at address zero
+    ///
+    /// (shouldn't be used because it's easy to make mistakes related to null pointers)
+    FrameZero,
+    /// an empty region with size 0
+    Empty,
+    /// used for storing the boot information
+    BootInfo,
+    /// used for storing the supplied package
+    Package,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub struct E820MemoryRegion {
+    pub start_addr: u64,
+    pub len: u64,
+    pub region_type: u32,
+    pub acpi_extended_attributes: u32,
+}
+
+impl From<E820MemoryRegion> for MemoryRegion {
+    fn from(region: E820MemoryRegion) -> MemoryRegion {
+        let region_type = match region.region_type {
+            1 => MemoryRegionType::Usable,
+            2 => MemoryRegionType::Reserved,
+            3 => MemoryRegionType::AcpiReclaimable,
+            4 => MemoryRegionType::AcpiNvs,
+            5 => MemoryRegionType::BadMemory,
+            t => panic!("invalid region type {}", t),
+        };
+        MemoryRegion {
+            range: FrameRange::new(region.start_addr, region.start_addr + region.len),
+            region_type,
+        }
+    }
+}
+
+extern "C" {
+    fn _improper_ctypes_check(_boot_info: MemoryMap);
+}

--- a/src/bootinfo/memory_map.rs
+++ b/src/bootinfo/memory_map.rs
@@ -34,17 +34,15 @@ impl MemoryMap {
             } else if r2.range.is_empty() {
                 Ordering::Less
             } else {
-                
-                let ordering = r1.range
+                let ordering = r1
+                    .range
                     .start_frame_number
                     .cmp(&r2.range.start_frame_number);
-                
+
                 if ordering == Ordering::Equal {
-                    r1.range
-                    .end_frame_number
-                    .cmp(&r2.range.end_frame_number)
+                    r1.range.end_frame_number.cmp(&r2.range.end_frame_number)
                 } else {
-                    ordering   
+                    ordering
                 }
             }
         });

--- a/src/bootinfo/mod.rs
+++ b/src/bootinfo/mod.rs
@@ -1,8 +1,8 @@
 #![deny(improper_ctypes)]
 
+pub use self::memory_map::*;
 use core::ops::Deref;
 use core::slice;
-pub use self::memory_map::*;
 
 mod memory_map;
 
@@ -45,7 +45,10 @@ extern "C" {
     fn _improper_ctypes_check(_boot_info: BootInfo);
 }
 
-use x86_64::{PhysAddr, structures::paging::{PhysFrame, PhysFrameRange}};
+use x86_64::{
+    structures::paging::{PhysFrame, PhysFrameRange},
+    PhysAddr,
+};
 
 impl From<FrameRange> for PhysFrameRange {
     fn from(range: FrameRange) -> Self {

--- a/src/bootinfo/mod.rs
+++ b/src/bootinfo/mod.rs
@@ -1,0 +1,66 @@
+#![deny(improper_ctypes)]
+
+use core::ops::Deref;
+use core::slice;
+pub use self::memory_map::*;
+
+mod memory_map;
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct BootInfo {
+    pub p4_table_addr: u64,
+    pub memory_map: MemoryMap,
+    pub package: Package,
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct Package {
+    ptr: *const u8,
+    len: u64,
+}
+
+impl Deref for Package {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        unsafe { slice::from_raw_parts(self.ptr, self.len as usize) }
+    }
+}
+
+impl BootInfo {
+    pub fn new(p4_table_addr: u64, memory_map: MemoryMap, package: &'static [u8]) -> Self {
+        BootInfo {
+            p4_table_addr,
+            memory_map,
+            package: Package {
+                ptr: package.as_ptr(),
+                len: package.len() as u64,
+            },
+        }
+    }
+}
+
+extern "C" {
+    fn _improper_ctypes_check(_boot_info: BootInfo);
+}
+
+use x86_64::{PhysAddr, structures::paging::{PhysFrame, PhysFrameRange}};
+
+impl From<FrameRange> for PhysFrameRange {
+    fn from(range: FrameRange) -> Self {
+        PhysFrameRange {
+            start: PhysFrame::from_start_address(PhysAddr::new(range.start_addr())).unwrap(),
+            end: PhysFrame::from_start_address(PhysAddr::new(range.end_addr())).unwrap(),
+        }
+    }
+}
+
+impl From<PhysFrameRange> for FrameRange {
+    fn from(range: PhysFrameRange) -> Self {
+        FrameRange::new(
+            range.start.start_address().as_u64(),
+            range.end.start_address().as_u64(),
+        )
+    }
+}

--- a/src/frame_allocator.rs
+++ b/src/frame_allocator.rs
@@ -52,8 +52,10 @@ impl<'a> FrameAllocator<'a> {
         };
 
         if let Some((frame, range)) = result {
-            self.memory_map
-                .add_region(MemoryRegion { range: range.into(), region_type });
+            self.memory_map.add_region(MemoryRegion {
+                range: range.into(),
+                region_type,
+            });
             Some(frame)
         } else {
             None

--- a/src/frame_allocator.rs
+++ b/src/frame_allocator.rs
@@ -1,4 +1,4 @@
-use os_bootinfo::{MemoryMap, MemoryRegion, MemoryRegionType};
+use bootloader::bootinfo::{MemoryMap, MemoryRegion, MemoryRegionType};
 use x86_64::structures::paging::{PhysFrame, PhysFrameRange};
 
 pub(crate) struct FrameAllocator<'a> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,8 @@
 #![no_std]
 
-extern crate os_bootinfo;
+extern crate x86_64;
 
-pub mod bootinfo {
-    pub use os_bootinfo::*;
-}
+pub mod bootinfo;
 
 /// Defines the entry point function.
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,9 +16,9 @@ extern crate xmas_elf;
 #[macro_use]
 extern crate fixedvec;
 
-use core::slice;
-use core::panic::PanicInfo;
 use bootloader::bootinfo::BootInfo;
+use core::panic::PanicInfo;
+use core::slice;
 use usize_conversions::usize_from;
 use x86_64::structures::paging::{Mapper, RecursivePageTable};
 use x86_64::structures::paging::{Page, PageTableFlags, PhysFrame, Size2MiB};
@@ -67,8 +67,8 @@ pub extern "C" fn load_elf(
     bootloader_start: PhysAddr,
     bootloader_end: PhysAddr,
 ) -> ! {
-    use fixedvec::FixedVec;
     use bootloader::bootinfo::{MemoryRegion, MemoryRegionType};
+    use fixedvec::FixedVec;
     use xmas_elf::program::{ProgramHeader, ProgramHeader64};
 
     printer::Printer.clear_screen();
@@ -117,7 +117,6 @@ pub extern "C" fn load_elf(
         memory_map: &mut memory_map,
     };
 
-
     // Mark already used memory areas in frame allocator.
     {
         let zero_frame: PhysFrame = PhysFrame::from_start_address(PhysAddr::new(0)).unwrap();
@@ -151,7 +150,6 @@ pub extern "C" fn load_elf(
         });
     }
 
-
     // Unmap the ELF file.
     let kernel_start_page: Page<Size2MiB> = Page::containing_address(kernel_start.virt());
     let kernel_end_page: Page<Size2MiB> =
@@ -181,12 +179,17 @@ pub extern "C" fn load_elf(
             flags,
             &mut rec_page_table,
             &mut frame_allocator,
-        ).expect("Mapping of bootinfo page failed").flush();
+        ).expect("Mapping of bootinfo page failed")
+        .flush();
         page
     };
 
     // Construct boot info structure.
-    let mut boot_info = BootInfo::new(recursive_page_table_addr.start_address().as_u64(), memory_map, &[]);
+    let mut boot_info = BootInfo::new(
+        recursive_page_table_addr.start_address().as_u64(),
+        memory_map,
+        &[],
+    );
     boot_info.memory_map.sort();
 
     // Write boot info to boot info page.

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@
 #![no_std]
 #![no_main]
 
-extern crate os_bootinfo;
+extern crate bootloader;
 extern crate usize_conversions;
 extern crate x86_64;
 extern crate xmas_elf;
@@ -18,7 +18,7 @@ extern crate fixedvec;
 
 use core::slice;
 use core::panic::PanicInfo;
-use os_bootinfo::BootInfo;
+use bootloader::bootinfo::BootInfo;
 use usize_conversions::usize_from;
 use x86_64::structures::paging::{Mapper, RecursivePageTable};
 use x86_64::structures::paging::{Page, PageTableFlags, PhysFrame, Size2MiB};
@@ -68,7 +68,7 @@ pub extern "C" fn load_elf(
     bootloader_end: PhysAddr,
 ) -> ! {
     use fixedvec::FixedVec;
-    use os_bootinfo::{MemoryRegion, MemoryRegionType};
+    use bootloader::bootinfo::{MemoryRegion, MemoryRegionType};
     use xmas_elf::program::{ProgramHeader, ProgramHeader64};
 
     printer::Printer.clear_screen();
@@ -186,7 +186,7 @@ pub extern "C" fn load_elf(
     };
 
     // Construct boot info structure.
-    let mut boot_info = BootInfo::new(recursive_page_table_addr.start_address().as_u64(), memory_map);
+    let mut boot_info = BootInfo::new(recursive_page_table_addr.start_address().as_u64(), memory_map, &[]);
     boot_info.memory_map.sort();
 
     // Write boot info to boot info page.

--- a/src/page_table.rs
+++ b/src/page_table.rs
@@ -1,8 +1,10 @@
+use bootloader::bootinfo::MemoryRegionType;
 use fixedvec::FixedVec;
 use frame_allocator::FrameAllocator;
-use bootloader::bootinfo::MemoryRegionType;
 use x86_64::structures::paging::{self, MapToError, RecursivePageTable, UnmapError};
-use x86_64::structures::paging::{Mapper, MapperFlush, Page, PageSize, PageTableFlags, PhysFrame, Size4KiB};
+use x86_64::structures::paging::{
+    Mapper, MapperFlush, Page, PageSize, PageTableFlags, PhysFrame, Size4KiB,
+};
 use x86_64::{align_up, PhysAddr, VirtAddr};
 use xmas_elf::program::{self, ProgramHeader64};
 
@@ -105,9 +107,7 @@ pub(crate) fn map_segment(
                     // remap last page
                     if let Err(e) = page_table.unmap(last_page.clone()) {
                         return Err(match e {
-                            UnmapError::ParentEntryHugePage => {
-                                MapToError::ParentEntryHugePage
-                            }
+                            UnmapError::ParentEntryHugePage => MapToError::ParentEntryHugePage,
                             UnmapError::PageNotMapped => unreachable!(),
                             UnmapError::InvalidFrameAddress(_) => unreachable!(),
                         });
@@ -166,5 +166,10 @@ where
         }
     }
 
-    page_table.map_to(page, phys_frame, flags, &mut PageTableAllocator(frame_allocator))
+    page_table.map_to(
+        page,
+        phys_frame,
+        flags,
+        &mut PageTableAllocator(frame_allocator),
+    )
 }

--- a/src/page_table.rs
+++ b/src/page_table.rs
@@ -1,6 +1,6 @@
 use fixedvec::FixedVec;
 use frame_allocator::FrameAllocator;
-use os_bootinfo::MemoryRegionType;
+use bootloader::bootinfo::MemoryRegionType;
 use x86_64::structures::paging::{self, MapToError, RecursivePageTable, UnmapError};
 use x86_64::structures::paging::{Mapper, MapperFlush, Page, PageSize, PageTableFlags, PhysFrame, Size4KiB};
 use x86_64::{align_up, PhysAddr, VirtAddr};


### PR DESCRIPTION
- Remove VERSION constant: The kernel can no longer have a separate dependency on os_bootinfo, so it is guaranteed that the bootinfo versions match.
- Implement the From trait to convert between the frame range types of bootinfo and x86_64.