### PR TITLE
Remove stabilized features

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,6 @@
 #![feature(asm)]
 #![feature(nll)]
 #![feature(const_fn)]
-#![feature(panic_implementation)]
 #![no_std]
 #![no_main]
 
@@ -214,7 +213,7 @@ fn enable_write_protect_bit() {
     unsafe { Cr0::update(|cr0| *cr0 |= Cr0Flags::WRITE_PROTECT) };
 }
 
-#[panic_implementation]
+#[panic_handler]
 #[no_mangle]
 pub extern "C" fn panic(info: &PanicInfo) -> ! {
     use core::fmt::Write;


### PR DESCRIPTION
- panic_implemenation was renamed to panic_handler:
   - https://github.com/rust-lang/rust/issues/44489#issuecomment-415140224
- panic_handler was stablized:
   - https://github.com/rust-lang/rust/pull/51366
- `cargo check` now succeeds without warnings