### PR TITLE
Use LLD for linking, fix page table zeroing, increase memory map size, improve errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -14,7 +14,7 @@ version = "0.3.2"
 dependencies = [
  "fixedvec 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "usize_conversions 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "x86_64 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x86_64 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "xmas-elf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -31,7 +31,7 @@ name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -73,7 +73,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -81,7 +81,7 @@ name = "remove_dir_all"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -119,7 +119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -138,11 +138,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "x86_64"
-version = "0.2.11"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bit_field 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "os_bootinfo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "usize_conversions 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ux 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -163,7 +163,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum bit_field 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed8765909f9009617974ab6b7d332625b320b33c326b1e9321382ef1999b5d56"
-"checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
+"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum fixedvec 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7c6c16d316ccdac21a4dd648e314e76facbbaf316e83ca137d0857a9c07419d0"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
@@ -178,9 +178,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum usize_conversions 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f70329e2cbe45d6c97a5112daad40c34cd9a4e18edb5a2a18fefeb584d8d25e5"
 "checksum ux 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53d8df5dd8d07fedccd202de1887d94481fadaea3db70479f459e8163a1fab41"
-"checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
+"checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum x86_64 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "466c2002e38edde7ebbaae6656793d4f71596634971c7e8cbf7afa4827968445"
+"checksum x86_64 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2bd647af1614659e1febec1d681231aea4ebda4818bf55a578aff02f3e4db4b4"
 "checksum xmas-elf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "22678df5df766e8d1e5d609da69f0c3132d794edf6ab5e75e7abcd2270d4cf58"
 "checksum zero 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5f1bc8a6b2005884962297587045002d8cfb8dcec9db332f4ca216ddc5de82c5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bootloader"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "fixedvec 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "usize_conversions 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/linker.ld
+++ b/linker.ld
@@ -37,6 +37,7 @@ SECTIONS {
         *(.text .text.*)
         *(.rodata .rodata.*)
         *(.data .data.*)
+        *(.got)
         . = ALIGN(512);
         _rest_of_bootloader_end_addr = .;
     }

--- a/linker.ld
+++ b/linker.ld
@@ -28,17 +28,17 @@ SECTIONS {
     .bootloader :
     {
         /* first stage */
-        *(.boot)
+        *(.boot-first-stage)
 
-        /* second stage */
-        _second_stage_start_addr = .;
-        *(.second_stage)
+        /* rest of bootloader */
+        _rest_of_bootloader_start_addr = .;
+        *(.boot)
         *(.context_switch)
         *(.text .text.*)
         *(.rodata .rodata.*)
         *(.data .data.*)
         . = ALIGN(512);
-        _second_stage_end_addr = .;
+        _rest_of_bootloader_end_addr = .;
     }
 
     _kernel_info_block_start = .;

--- a/src/bootinfo/memory_map.rs
+++ b/src/bootinfo/memory_map.rs
@@ -3,9 +3,11 @@ use core::ops::{Deref, DerefMut};
 
 const PAGE_SIZE: u64 = 4096;
 
+const MAX_MEMORY_MAP_SIZE: usize = 64;
+
 #[repr(C)]
 pub struct MemoryMap {
-    entries: [MemoryRegion; 32],
+    entries: [MemoryRegion; MAX_MEMORY_MAP_SIZE],
     // u64 instead of usize so that the structure layout is platform
     // independent
     next_entry_index: u64,
@@ -14,7 +16,7 @@ pub struct MemoryMap {
 impl MemoryMap {
     pub fn new() -> Self {
         MemoryMap {
-            entries: [MemoryRegion::empty(); 32],
+            entries: [MemoryRegion::empty(); MAX_MEMORY_MAP_SIZE],
             next_entry_index: 0,
         }
     }

--- a/src/bootinfo/memory_map.rs
+++ b/src/bootinfo/memory_map.rs
@@ -22,6 +22,8 @@ impl MemoryMap {
     }
 
     pub fn add_region(&mut self, region: MemoryRegion) {
+        assert!(self.next_entry_index() < MAX_MEMORY_MAP_SIZE,
+            "too many memory regions in memory map");
         self.entries[self.next_entry_index()] = region;
         self.next_entry_index += 1;
         self.sort();

--- a/src/e820.s
+++ b/src/e820.s
@@ -1,4 +1,4 @@
-.section .second_stage, "awx"
+.section .boot, "awx"
 .intel_syntax noprefix
 .code16
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,9 +25,11 @@ use x86_64::ux::u9;
 pub use x86_64::PhysAddr;
 use x86_64::VirtAddr;
 
-global_asm!(include_str!("boot.s"));
-global_asm!(include_str!("second_stage.s"));
-global_asm!(include_str!("memory_map.s"));
+global_asm!(include_str!("stage_1.s"));
+global_asm!(include_str!("stage_2.s"));
+global_asm!(include_str!("e820.s"));
+global_asm!(include_str!("stage_3.s"));
+global_asm!(include_str!("stage_4.s"));
 global_asm!(include_str!("context_switch.s"));
 
 extern "C" {

--- a/src/stage_1.s
+++ b/src/stage_1.s
@@ -34,7 +34,7 @@ enter_protected_mode:
     push ds
     push es
 
-    lgdt [gdtinfo]
+    lgdt [gdt32info]
 
     mov eax, cr0
     or al, 1    # set protected mode bit
@@ -43,7 +43,7 @@ enter_protected_mode:
     jmp protected_mode                # tell 386/486 to not crash
 
 protected_mode:
-    mov bx, 0x8
+    mov bx, 0x10
     mov ds, bx # set data segment
     mov es, bx # set extra segment
 
@@ -183,14 +183,23 @@ no_cpuid_str: .asciz "No CPUID support"
 no_int13h_extensions_str: .asciz "No support for int13h extensions"
 rest_of_bootloader_load_failed_str: .asciz "Failed to load rest of bootloader"
 
-gdtinfo:
-   .word gdt_end - gdt - 1  # last byte in table
-   .word gdt                # start of table
+gdt32info:
+   .word gdt32_end - gdt32 - 1  # last byte in table
+   .word gdt32                  # start of table
 
-gdt:
+gdt32:
     # entry 0 is always unused
     .quad 0
-flatdesc:
+codedesc:
+    .byte 0xff
+    .byte 0xff
+    .byte 0
+    .byte 0
+    .byte 0
+    .byte 0x9a
+    .byte 0xcf
+    .byte 0
+datadesc:
     .byte 0xff
     .byte 0xff
     .byte 0
@@ -199,7 +208,7 @@ flatdesc:
     .byte 0x92
     .byte 0xcf
     .byte 0
-gdt_end:
+gdt32_end:
 
 dap: # disk access packet
     .byte 0x10 # size of dap

--- a/src/stage_1.s
+++ b/src/stage_1.s
@@ -3,6 +3,9 @@
 .intel_syntax noprefix
 .code16
 
+# This stage initializes the stack, enables the A20 line, loads the rest of
+# the bootloader from disk, and jumps to stage_2.
+
 _start:
     # zero segment registers
     xor ax, ax

--- a/src/stage_2.s
+++ b/src/stage_2.s
@@ -3,13 +3,18 @@
 .code16
 
 second_stage_start_str: .asciz "Booting (second stage)..."
-loading_kernel_block_str: .asciz "loading kernel block..."
-kernel_load_failed_str: .asciz "Failed to load kernel"
+kernel_load_failed_str: .asciz "Failed to load kernel from disk"
 
 kernel_load_failed:
-jmp kernel_load_failed
+    lea si, [kernel_load_failed_str]
+    call println
+kernel_load_failed_spin:
+    jmp kernel_load_failed_spin
 
 stage_2:
+    lea si, [second_stage_start_str]
+    call println
+
 set_target_operating_mode:
     # Some BIOSs assume the processor will only operate in Legacy Mode. We change the Target
     # Operating Mode to "Long Mode Target Only", so the firmware expects each CPU to enter Long Mode

--- a/src/stage_2.s
+++ b/src/stage_2.s
@@ -1,0 +1,86 @@
+.section .boot, "awx"
+.intel_syntax noprefix
+.code16
+
+second_stage_start_str: .asciz "Booting (second stage)..."
+loading_kernel_block_str: .asciz "loading kernel block..."
+kernel_load_failed_str: .asciz "Failed to load kernel"
+
+kernel_load_failed:
+jmp kernel_load_failed
+
+stage_2:
+set_target_operating_mode:
+    # Some BIOSs assume the processor will only operate in Legacy Mode. We change the Target
+    # Operating Mode to "Long Mode Target Only", so the firmware expects each CPU to enter Long Mode
+    # once and then stay in it. This allows the firmware to enable mode-specifc optimizations.
+    # We save the flags, because CF is set if the callback is not supported (in which case, this is
+    # a NOP)
+    pushf
+    mov ax, 0xec00
+    mov bl, 0x2
+    int 0x15
+    popf
+
+load_kernel_from_disk:
+    # start of memory buffer
+    lea eax, _kernel_buffer
+    mov [dap_buffer_addr], ax
+
+    # number of disk blocks to load
+    mov word ptr [dap_blocks], 1
+
+    # number of start block
+    lea eax, _kernel_start_addr
+    lea ebx, _start
+    sub eax, ebx
+    shr eax, 9 # divide by 512 (block size)
+    mov [dap_start_lba], eax
+
+    # destination address
+    mov edi, 0x400000
+
+    # block count
+    mov ecx, _kib_kernel_size
+    add ecx, 511 # align up
+    shr ecx, 9
+
+load_next_kernel_block_from_disk:
+    # load block from disk
+    lea si, dap
+    mov ah, 0x42
+    int 0x13
+    jc kernel_load_failed
+
+    # copy block to 2MiB
+    push ecx
+    push esi
+    mov ecx, 512 / 4
+    # move with zero extension
+    # because we are moving a word ptr
+    # to esi, a 32-bit register.
+    movzx esi, word ptr [dap_buffer_addr]
+    # move from esi to edi ecx times.
+    rep movsd [edi], [esi]
+    pop esi
+    pop ecx
+
+    # next block
+    mov eax, [dap_start_lba]
+    add eax, 1
+    mov [dap_start_lba], eax
+
+    sub ecx, 1
+    jnz load_next_kernel_block_from_disk
+
+create_memory_map:
+    lea di, es:[_memory_map]
+    call do_e820
+
+enter_protected_mode_again:
+jmp enter_protected_mode_again
+
+    lea eax, [stage_3]
+    jmp eax
+spin32:
+    jmp spin32

--- a/src/stage_2.s
+++ b/src/stage_2.s
@@ -78,9 +78,16 @@ create_memory_map:
     call do_e820
 
 enter_protected_mode_again:
-jmp enter_protected_mode_again
+    cli
+    lgdt [gdt32info]
+    mov eax, cr0
+    or al, 1    # set protected mode bit
+    mov cr0, eax
 
+    push 0x8
     lea eax, [stage_3]
-    jmp eax
+    push eax
+    retf
+
 spin32:
     jmp spin32

--- a/src/stage_2.s
+++ b/src/stage_2.s
@@ -2,6 +2,10 @@
 .intel_syntax noprefix
 .code16
 
+# This stage sets the target operating mode, loads the kernel from disk,
+# creates an e820 memory map, enters protected mode, and jumps to the
+# third stage.
+
 second_stage_start_str: .asciz "Booting (second stage)..."
 kernel_load_failed_str: .asciz "Failed to load kernel from disk"
 

--- a/src/stage_3.s
+++ b/src/stage_3.s
@@ -90,6 +90,11 @@ set_up_page_tables:
     mov [_p1 + ecx * 8], eax
 
 enable_paging:
+    # Write back cache and add a memory fence. I'm not sure if this is
+    # necessary, but better be on the safe side.
+    wbinvd
+    mfence
+
     # load P4 to cr3 register (cpu uses this to access the P4 table)
     lea eax, [_p4]
     mov cr3, eax

--- a/src/stage_3.s
+++ b/src/stage_3.s
@@ -5,6 +5,11 @@
 no_long_mode_str: .asciz "No long mode support"
 
 stage_3:
+    mov bx, 0x10
+    mov ds, bx # set data segment
+    mov es, bx # set extra segment
+    mov ss, bx # set stack segment
+
 check_cpu:
     call check_cpuid
     call check_long_mode

--- a/src/stage_3.s
+++ b/src/stage_3.s
@@ -105,7 +105,7 @@ enable_paging:
 
     # enable paging in the cr0 register
     mov eax, cr0
-    or eax, ((1 << 31) | 1)
+    or eax, (1 << 31)
     mov cr0, eax
 
 load_64bit_gdt:

--- a/src/stage_3.s
+++ b/src/stage_3.s
@@ -32,8 +32,10 @@ check_cpu:
 
 set_up_page_tables:
     # zero out buffer for page tables
-    lea edi, [_p4]
-    mov ecx, 0x1000 / 4 * 3
+    lea edi, [__page_table_start]
+    lea ecx, [__page_table_end]
+    sub ecx, edi
+    shr ecx, 2 # one stosd zeros 4 bytes -> divide by 4
     xor eax, eax
     rep stosd
 

--- a/src/stage_3.s
+++ b/src/stage_3.s
@@ -2,6 +2,11 @@
 .intel_syntax noprefix
 .code32
 
+# This stage performs some checks on the CPU (cpuid, long mode), sets up an
+# initial page table mapping (identity map the bootloader, map the P4
+# recursively, map the kernel blob to 4MB), enables paging, switches to long
+# mode, and jumps to stage_4.
+
 stage_3:
     mov bx, 0x10
     mov ds, bx # set data segment

--- a/src/stage_3.s
+++ b/src/stage_3.s
@@ -2,13 +2,23 @@
 .intel_syntax noprefix
 .code32
 
-no_long_mode_str: .asciz "No long mode support"
-
 stage_3:
     mov bx, 0x10
     mov ds, bx # set data segment
     mov es, bx # set extra segment
     mov ss, bx # set stack segment
+
+    # print "3rd stage" to the top right
+    mov eax, 0x0f720f33 # "3r"
+    mov [0xb808c], eax
+    mov eax, 0x0f200f64 # "d "
+    mov [0xb808c + 4], eax
+    mov eax, 0x0f740f73 # "st"
+    mov [0xb808c + 8], eax
+    mov eax, 0x0f670f61 # "ag"
+    mov [0xb808c + 12], eax
+    mov eax, 0x0f200f65 # "e "
+    mov [0xb808c + 16], eax
 
 check_cpu:
     call check_cpuid
@@ -143,8 +153,18 @@ check_cpuid:
     je no_cpuid
     ret
 no_cpuid:
-    lea si, no_cpuid_str
-    jmp no_cpuid
+    # print "no cpuid" to the top right
+    mov eax, 0x4f6f4f6e # "no"
+    mov [0xb8130], eax
+    mov eax, 0x4f634f20 # " c"
+    mov [0xb8130 + 4], eax
+    mov eax, 0x4f754f70 # "pu"
+    mov [0xb8130 + 8], eax
+    mov eax, 0x4f644f69 # "id"
+    mov [0xb8130 + 12], eax
+no_cpuid_spin:
+    hlt
+    jmp no_cpuid_spin
 
 check_long_mode:
     # test if extended processor info in available
@@ -160,8 +180,22 @@ check_long_mode:
     jz no_long_mode        # If it's not set, there is no long mode
     ret
 no_long_mode:
-    lea si, no_long_mode_str
-    jmp no_long_mode
+    # print "no long mode" to the top right
+    mov eax, 0x4f6f4f6e # "no"
+    mov [0xb8128], eax
+    mov eax, 0x4f6c4f20 # " l"
+    mov [0xb8128 + 4], eax
+    mov eax, 0x4f6e4f6f # "on"
+    mov [0xb8128 + 8], eax
+    mov eax, 0x4f204f67 # "g "
+    mov [0xb8128 + 12], eax
+    mov eax, 0x4f6f4f6d # "mo"
+    mov [0xb8128 + 16], eax
+    mov eax, 0x4f654f64 # "de"
+    mov [0xb8128 + 20], eax
+no_long_mode_spin:
+    hlt
+    jmp no_long_mode_spin
 
 
 .align 4

--- a/src/stage_4.s
+++ b/src/stage_4.s
@@ -1,0 +1,19 @@
+.section .boot, "awx"
+.intel_syntax noprefix
+.code64
+
+stage_4:
+    # call load_elf with kernel start address, size, and memory map as arguments
+    movabs rdi, 0x400000 # move absolute 64-bit to register
+    mov rsi, _kib_kernel_size
+    lea rdx, _memory_map
+    movzx rcx, word ptr mmap_ent
+    lea r8, __page_table_start
+    lea r9, __page_table_end
+    lea rax, __bootloader_end
+    push rax
+    lea rax, __bootloader_start
+    push rax
+    call load_elf
+spin64:
+    jmp spin64

--- a/src/stage_4.s
+++ b/src/stage_4.s
@@ -2,6 +2,8 @@
 .intel_syntax noprefix
 .code64
 
+# This stage calls into Rust code, passing various values as arguments.
+
 stage_4:
     # call load_elf with kernel start address, size, and memory map as arguments
     movabs rdi, 0x400000 # move absolute 64-bit to register

--- a/x86_64-bootloader.json
+++ b/x86_64-bootloader.json
@@ -1,10 +1,10 @@
 {
     "llvm-target": "x86_64-unknown-none-gnu",
     "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
-    "linker-flavor": "ld",
-    "linker": "ld.bfd",
+    "linker-flavor": "ld.lld",
+    "linker": "rust-lld",
     "pre-link-args": {
-        "ld": [
+        "ld.lld": [
 	    "--script=linker.ld"
 	]
     },


### PR DESCRIPTION
This PR combines some updates to the bootloader:

- **More stages**: I split the second stage into three separate stages (16-bit, 32-bit, 64-bit) to make them shorter.
- **Use LLD for linking**: I was able to identify and rewrite the problematic relocations that prevented us from linking with LLD. This means that we no longer need bootloader_precompiled, as the bootloader should now compile on Linux, macOS, and Windows.
- **Go through protected mode** instead of jumping directly from real mode to long mode. This is not necessary, but I had some problems to run the bootloader on real hardware, so I tried to keep things the standard way (the problem turned out to be somewhere else).
- **Fix page table zeroing**: The code for zeroing the initial page tables didn't zero the P1 table. This was a very ugly bug, because QEMU zeroes memory by default so that it only caused errors on real hardware.
- **Increase memory map size** to 64 entries. My laptop reports more than 32 memory regions, which caused the boot to fail.

There were also some minor changes such as updating the Cargo.lock and some changes to make the bootloader more robust.