### PR TITLE
Fix spurious panic on some hardware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bootloader"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "fixedvec 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "usize_conversions 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["publish-lockfile"]
 
 [package]
 name = "bootloader"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 license = "MIT/Apache-2.0"
 description = "An experimental pure-Rust x86 bootloader."

--- a/src/boot_info.rs
+++ b/src/boot_info.rs
@@ -19,12 +19,10 @@ pub(crate) fn create_from(memory_map_addr: VirtAddr, entry_count: u64) -> Memory
     let mut iter = memory_map.iter_mut().peekable();
     while let Some(region) = iter.next() {
         if let Some(next) = iter.peek() {
-            if region.range.end_frame_number > next.range.start_frame_number {
-                if region.region_type == MemoryRegionType::Usable {
-                    region.range.end_frame_number = next.range.start_frame_number;
-                } else {
-                    panic!("two non-usable regions overlap: {:?} {:?}", region, next);
-                }
+            if region.range.end_frame_number > next.range.start_frame_number
+                && region.region_type == MemoryRegionType::Usable
+            {
+                region.range.end_frame_number = next.range.start_frame_number;
             }
         }
     }


### PR DESCRIPTION
Apparently, it is possible that non-usable memory regions overlap each other.
This is fixed simply by removing the detection of overlapping
non-usable memory and the associated panic.

Bump patch version to 0.3.5.
The change should be fully backwards-compatible.