### PR TITLE
add Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/
 **/*.rs.bk
+bootimage.bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,15 @@ language: rust
 rust:
 - nightly
 
-os: linux
+matrix:
+  include:
+    - os: linux
+    - os: osx
+
+addons:
+  homebrew:
+    packages:
+    - binutils
 
 cache:
   directories:
@@ -23,5 +31,4 @@ notifications:
     on_failure: change
 
 script:
-- RUST_TARGET_PATH=`pwd` xargo build --target x86_64-bootloader --release
-- objcopy -O binary -S target/x86_64-bootloader/release/bootloader bootimage.bin
+- make objcopy

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ objcopy: build
 endif
 ifeq ($(UNAME), Darwin)
 objcopy: build
+	# This is installed via `brew install binutils`
 	/usr/local/opt/binutils/bin/objcopy -O binary -S target/x86_64-bootloader/release/bootloader bootimage.bin
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 ifeq ($(UNAME), Darwin)
 objcopy: build
 	# This is installed via `brew install binutils`
-	/usr/local/opt/binutils/bin/objcopy -O binary -S target/x86_64-bootloader/release/bootloader bootimage.bin
+	/usr/local/opt/binutils/bin/gobjcopy -O binary -S target/x86_64-bootloader/release/bootloader bootimage.bin
 endif
 
 run: objcopy

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+default: run
+
+.PHONY: build objcopy run clean cleanall
+
+build:
+	RUST_TARGET_PATH=$(shell pwd) xargo build --target x86_64-bootloader --release
+
+UNAME := $(shell uname)
+ifeq ($(UNAME), Linux)
+objcopy: build
+	objcopy -O binary -S target/x86_64-bootloader/release/bootloader bootimage.bin
+endif
+ifeq ($(UNAME), Darwin)
+objcopy: build
+	/usr/local/opt/binutils/bin/objcopy -O binary -S target/x86_64-bootloader/release/bootloader bootimage.bin
+endif
+
+run: objcopy
+	qemu-system-x86_64 -hda bootimage.bin -d int -s
+
+clean:
+	rm -f bootimage.bin
+
+cleanall: clean
+	rm -rf target/
+

--- a/README.md
+++ b/README.md
@@ -9,7 +9,14 @@ An experimental pure-Rust x86 bootloader for the [planned second edition](https:
 The idea is to build the kernel as a `no_std` longmode executable and then build the bootloader with the kernel [ELF](https://en.wikipedia.org/wiki/Executable_and_Linkable_Format) file in `kernel.bin`. The output is a flat binary disk image (including a basic [MBR](https://en.wikipedia.org/wiki/Master_boot_record)) that can be run in [QEMU](https://www.qemu.org/) or burned to an USB flash drive (CDs require a different kind of bootloader, which is not supported at the moment). The plan is to create a custom tool (or cargo subcommand) that performs these steps automatically.
 
 ## Build and Run
-You need a nightly [Rust](https://www.rust-lang.org) compiler, [xargo](https://github.com/japaric/xargo), [objcopy](https://sourceware.org/binutils/docs/binutils/objcopy.html) (or a similar tool), and [QEMU](https://www.qemu.org/) (for running it).
+
+You need:
+
+* a nightly [Rust](https://www.rust-lang.org) compiler
+* [xargo](https://github.com/japaric/xargo) (`cargo install xargo`)
+* [objcopy](https://sourceware.org/binutils/docs/binutils/objcopy.html) (or a similar tool)
+	- Users on macOS can install this via `brew install binutils`
+* [QEMU](https://www.qemu.org/) (for running it)
 
 ### Mac OS
 


### PR DESCRIPTION
This PR adds a `Makefile` that works both on Linux and macOS (so we don't have to provide instructions in the `README.md`).

Make commands:

* `make`: defaults to `make run`
* `make build`: runs `xargo build`
* `make objcopy`: runs `objcopy` (on linux and macOS)
* `make run`: runs `qemu-system-x86_64`
* `make clean`: runs `rm -f bootimage.bin`
* `make cleanall`: runs `rm -rf target` (and the `make clean` target)

Not sure if you want to use `make` to build/run this project, since showing the build commands is also informative. Let me know how what you think.