### PR TITLE
Create new `builder` sub-crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ addons:
 
 install:
   - if [ $TRAVIS_OS_NAME = osx ]; then brew update; brew install qemu; fi
-  - if [ $TRAVIS_OS_NAME = windows ]; then wget https://qemu.weilnetz.de/w64/2018/qemu-w64-setup-20180801.exe; 7z x qemu-w64-setup-20180801.exe; fi
+  - if [ $TRAVIS_OS_NAME = windows ]; then choco install qemu; export PATH="/c/Program Files/qemu:$PATH"; fi
 
 before_script:
 - rustup component add rust-src

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,11 @@ addons:
   apt:
     packages:
       - qemu-system-x86
+  homebrew:
+    packages:
+      - qemu
 
 install:
-  - if [ $TRAVIS_OS_NAME = osx ]; then brew update; brew install qemu; fi
   - if [ $TRAVIS_OS_NAME = windows ]; then choco install qemu; export PATH="/c/Program Files/qemu:$PATH"; fi
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,30 @@ language: rust
 rust:
 - nightly
 
-os: linux
+os:
+  - linux
+  - osx
+  - windows
 
 cache:
   directories:
     - $HOME/.cargo
-    - $HOME/.xargo
+    - $HOME/Library/Caches/Homebrew
     - $TRAVIS_BUILD_DIR/target
+    - $TRAVIS_BUILD_DIR/example-kernel/target
+
+addons:
+  apt:
+    packages:
+      - qemu-system-x86
+
+install:
+  - if [ $TRAVIS_OS_NAME = osx ]; then brew update; brew install qemu; fi
+  - if [ $TRAVIS_OS_NAME = windows ]; then wget https://qemu.weilnetz.de/w64/2018/qemu-w64-setup-20180801.exe; 7z x qemu-w64-setup-20180801.exe; fi
 
 before_script:
 - rustup component add rust-src
-- "(test -x $HOME/.cargo/bin/xargo || cargo install xargo)"
+- "(test -x $HOME/.cargo/bin/cargo-xbuild || cargo install cargo-xbuild)"
 
 sudo: false
 
@@ -23,5 +36,6 @@ notifications:
     on_failure: change
 
 script:
-- RUST_TARGET_PATH=`pwd` xargo build --target x86_64-bootloader --release
-- objcopy -O binary -S target/x86_64-bootloader/release/bootloader bootimage.bin
+- cd example-kernel; cargo xbuild --target x86_64-example-kernel.json; cd ..
+- cd builder; cargo run -- --kernel ../example-kernel/target/x86_64-example-kernel/debug/example-kernel; cd ..
+- qemu-system-x86_64 -drive format=raw,file=target/x86_64-bootloader/release/bootimage.bin -device isa-debug-exit,iobase=0xf4,iosize=0x04 -display none; if [ $? -eq 123 ]; then (exit 0); else (exit 1); fi

--- a/README.md
+++ b/README.md
@@ -1,27 +1,37 @@
-# rustboot
+# bootloader
 
-[![Join the chat at https://gitter.im/rust-osdev/bootloader](https://badges.gitter.im/rust-osdev/bootloader.svg)](https://gitter.im/rust-osdev/bootloader?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/rust-osdev/bootloader.svg?branch=master)](https://travis-ci.org/rust-osdev/bootloader) [![Join the chat at https://gitter.im/rust-osdev/bootloader](https://badges.gitter.im/rust-osdev/bootloader.svg)](https://gitter.im/rust-osdev/bootloader?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-An experimental pure-Rust x86 bootloader for the [planned second edition](https://github.com/phil-opp/blog_os/issues/360) of the [Writing an OS in Rust](https://os.phil-opp.com) series.
+An experimental x86 bootloader written in Rust and inline assembly.
 
-**This is still work in progress**.
+Written for the [second edition](https://github.com/phil-opp/blog_os/issues/360) of the [Writing an OS in Rust](https://os.phil-opp.com) series.
 
-The idea is to build the kernel as a `no_std` longmode executable and then build the bootloader with the kernel [ELF](https://en.wikipedia.org/wiki/Executable_and_Linkable_Format) file in `kernel.bin`. The output is a flat binary disk image (including a basic [MBR](https://en.wikipedia.org/wiki/Master_boot_record)) that can be run in [QEMU](https://www.qemu.org/) or burned to an USB flash drive (CDs require a different kind of bootloader, which is not supported at the moment). The plan is to create a custom tool (or cargo subcommand) that performs these steps automatically.
+## Design
+
+TODO
 
 ## Build and Run
-You need a nightly [Rust](https://www.rust-lang.org) compiler, [xargo](https://github.com/japaric/xargo), [objcopy](https://sourceware.org/binutils/docs/binutils/objcopy.html) (or a similar tool), and [QEMU](https://www.qemu.org/) (for running it).
+You need a nightly [Rust](https://www.rust-lang.org) compiler and [cargo xbuild](https://github.com/rust-osdev/cargo-xbuild).
 
-### Mac OS
-
-If you are building on Mac OS and get a error saying `ld.bfd not found` you first need to [cross compile binutils](https://os.phil-opp.com/cross-compile-binutils) and then adjust
-the linker name in the `x86_64-bootloader.json` file. The reason for this is the default rust LLVM linker doesn't support some features this project needs.
-
-After doing that continue with the instructions for Linux.
-
-### Linux
+Then you can run the `builder` executable with your kernel as argument:
 
 ```
-> RUST_TARGET_PATH=$(pwd) xargo build --target x86_64-bootloader --release
-> objcopy -O binary -S target/x86_64-bootloader/release/bootloader bootimage.bin
-> qemu-system-x86_64 -hda bootimage.bin -d int -s
+cd builder
+cargo run -- --kernel path/to/your/kernel/elf/file
 ```
+
+This will output a file named `bootimage.bin` in the `../target/x86_64-bootloader/release` folder.
+
+You can run this file using [QEMU](https://www.qemu.org/):
+
+```
+qemu-system-x86_64 -drive format=raw,file=target/x86_64-bootloader/release/bootimage.bin
+```
+
+Or burn it to an USB drive:
+
+```
+dd if=target/x86_64-blog_os/debug/bootimage-blog_os.bin of=/dev/sdX && sync
+```
+
+Where sdX is the device name of your USB stick. **Be careful** to choose the correct device name, because everything on that device is overwritten.

--- a/builder/.gitignore
+++ b/builder/.gitignore
@@ -1,0 +1,2 @@
+/target/
+**/*.rs.bk

--- a/builder/Cargo.lock
+++ b/builder/Cargo.lock
@@ -1,0 +1,72 @@
+[[package]]
+name = "args"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "builder"
+version = "0.1.0"
+dependencies = [
+ "args 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xmas-elf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "getopts"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "xmas-elf"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "zero 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zero"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum args 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4b7432c65177b8d5c032d56e020dd8d407e939468479fc8c300e2d93e6d970b"
+"checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
+"checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
+"checksum getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0a7292d30132fb5424b354f5dc02512a86e4c516fe544bb7a25e7f266951b797"
+"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
+"checksum xmas-elf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "22678df5df766e8d1e5d609da69f0c3132d794edf6ab5e75e7abcd2270d4cf58"
+"checksum zero 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5f1bc8a6b2005884962297587045002d8cfb8dcec9db332f4ca216ddc5de82c5"

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "builder"
+version = "0.1.0"
+authors = ["Philipp Oppermann <dev@phil-opp.com>"]
+edition = "2018"
+
+[dependencies]
+xmas-elf = "0.6.2"
+byteorder = "1.2.7"
+args = "2.2.0"
+getopts = "0.2.18"

--- a/builder/src/main.rs
+++ b/builder/src/main.rs
@@ -1,0 +1,219 @@
+use args::Args;
+use byteorder::{ByteOrder, LittleEndian};
+use std::{
+    fs::File,
+    io::{self, Read, Write},
+    path::Path,
+    process,
+};
+
+const PROGRAM_NAME: &'static str = "builder";
+const PROGRAM_DESC: &'static str = "Builds the bootloader crate.";
+
+const BLOCK_SIZE: usize = 512;
+type KernelInfoBlock = [u8; BLOCK_SIZE];
+
+fn main() {
+    let mut args = args();
+
+    if help_arg_present() {
+        println!("{}", args.full_usage());
+        process::exit(0);
+    }
+
+    if let Err(args_err) = args.parse_from_cli() {
+        writeln!(io::stderr(), "{}", args_err).expect("Failed to write to stderr");
+        process::exit(1);
+    };
+
+    // load kernel
+
+    let kernel_path: String = args.value_of("kernel").unwrap();
+    let kernel_path = Path::new(&kernel_path);
+    let mut kernel_file = match File::open(kernel_path) {
+        Ok(file) => file,
+        Err(err) => {
+            writeln!(io::stderr(), "Failed to open kernel at {:?}: {}", kernel_path, err)
+                .expect("Failed to write to stderr");
+            process::exit(1);
+        }
+    };
+    let kernel_size = kernel_file
+        .metadata()
+        .map(|m| m.len())
+        .unwrap_or_else(|err| {
+            writeln!(io::stderr(), "Failed to read size of kernel: {}", err)
+                .expect("Failed to write to stderr");
+            process::exit(1);
+        });
+    let kernel_info_block = create_kernel_info_block(kernel_size, None);
+
+    // build bootloader
+
+    let mut build_args = vec![
+        "--manifest-path".into(),
+        "../Cargo.toml".into(),
+        "--target".into(),
+        "../x86_64-bootloader.json".into(),
+        "--release".into(),
+    ];
+    if args.value_of("no-default-features").unwrap() {
+        build_args.push("--no-default-features".into());
+    }
+    if args.value_of("all-features").unwrap() {
+        build_args.push("--all-features".into());
+    }
+    if let Some(features) = args.optional_value_of("features").unwrap() {
+        build_args.push("--features".into());
+        build_args.push(features);
+    }
+
+    let exit_status = run_xbuild(&build_args);
+    if !exit_status.map(|s| s.success()).unwrap_or(false) {
+        process::exit(1)
+    }
+
+    let bootloader_elf_path = Path::new("../target/x86_64-bootloader/release/bootloader");
+    let mut bootloader_elf_bytes = Vec::new();
+    File::open(bootloader_elf_path)
+        .and_then(|mut f| f.read_to_end(&mut bootloader_elf_bytes))
+        .expect("failed to read bootloader ELF file");
+
+    // read bootloader section of ELF file
+
+    let elf_file = xmas_elf::ElfFile::new(&bootloader_elf_bytes).unwrap();
+    xmas_elf::header::sanity_check(&elf_file).unwrap();
+    let bootloader_section = elf_file
+        .find_section_by_name(".bootloader")
+        .expect("bootloader must have a .bootloader section");
+    let bootloader_bytes = bootloader_section.raw_data(&elf_file);
+
+    // create output file
+
+    let output_file_path = Path::new("../target/x86_64-bootloader/release/bootimage.bin");
+
+    let mut output_file = File::create(output_file_path).expect("Failed to create output file");
+    output_file
+        .write_all(bootloader_bytes)
+        .expect("Failed to write bootloader bytes to output file");
+    output_file
+        .write_all(&kernel_info_block)
+        .expect("Failed to write kernel info block to output file");
+
+    write_file_to_file(&mut output_file, &mut kernel_file)
+        .expect("Failed to write kernel to output file");
+    pad_file(&mut output_file, kernel_size as usize, &[0; 512]).expect("Failed to pad file");
+}
+
+fn args() -> Args {
+    use getopts::Occur;
+
+    let mut args = Args::new(PROGRAM_NAME, PROGRAM_DESC);
+    args.flag("h", "help", "Prints the help message");
+    args.option(
+        "",
+        "kernel",
+        "Path to the kernel ELF file",
+        "KERNEL_PATH",
+        Occur::Req,
+        None,
+    );
+    args.option(
+        "",
+        "features",
+        "Space-separated list of features to activate",
+        "FEATURES",
+        Occur::Optional,
+        None,
+    );
+    args.flag("", "all-features", "Activate all available features");
+    args.flag(
+        "",
+        "no-default-features",
+        "Do not activate the `default` feature",
+    );
+    args
+}
+
+fn help_arg_present() -> bool {
+    std::env::args()
+        .find(|a| a == "--help" || a == "-h")
+        .is_some()
+}
+
+fn run_xbuild(args: &[String]) -> io::Result<process::ExitStatus> {
+    let mut command = process::Command::new("cargo");
+    command.arg("xbuild");
+    command.args(args);
+    let exit_status = command.status()?;
+
+    if !exit_status.success() {
+        let mut help_command = process::Command::new("cargo");
+        help_command.arg("xbuild").arg("--help");
+        help_command.stdout(process::Stdio::null());
+        help_command.stderr(process::Stdio::null());
+        if let Ok(help_exit_status) = help_command.status() {
+            if !help_exit_status.success() {
+                let mut stderr = io::stderr();
+                writeln!(
+                    stderr,
+                    "Failed to run `cargo xbuild`. Perhaps it is not installed?"
+                )?;
+                writeln!(stderr, "Run `cargo install cargo-xbuild` to install it.")?;
+            }
+        }
+    }
+
+    Ok(exit_status)
+}
+
+fn create_kernel_info_block(kernel_size: u64, maybe_package_size: Option<u64>) -> KernelInfoBlock {
+    let kernel_size = if kernel_size <= u64::from(u32::max_value()) {
+        kernel_size as u32
+    } else {
+        panic!("Kernel can't be loaded by BIOS bootloader because is too big")
+    };
+
+    let package_size = if let Some(size) = maybe_package_size {
+        if size <= u64::from(u32::max_value()) {
+            size as u32
+        } else {
+            panic!("Package can't be loaded by BIOS bootloader because is too big")
+        }
+    } else {
+        0
+    };
+
+    let mut kernel_info_block = [0u8; BLOCK_SIZE];
+    LittleEndian::write_u32(&mut kernel_info_block[0..4], kernel_size);
+    LittleEndian::write_u32(&mut kernel_info_block[8..12], package_size);
+
+    kernel_info_block
+}
+
+fn write_file_to_file(output: &mut File, datafile: &mut File) -> io::Result<()> {
+    let data_size = datafile.metadata()?.len();
+    let mut buffer = [0u8; 1024];
+    let mut acc = 0;
+    loop {
+        let (n, interrupted) = match datafile.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(n) => (n, false),
+            Err(ref e) if e.kind() == io::ErrorKind::Interrupted => (0, true),
+            Err(e) => Err(e)?,
+        };
+        if !interrupted {
+            acc += n;
+            output.write_all(&buffer[..n])?
+        }
+    }
+
+    assert!(data_size == acc as u64);
+
+    Ok(())
+}
+
+fn pad_file(output: &mut File, written_size: usize, padding: &[u8]) -> io::Result<()> {
+    let padding_size = (padding.len() - (written_size % padding.len())) % padding.len();
+    output.write_all(&padding[..padding_size])
+}

--- a/example-kernel/.gitignore
+++ b/example-kernel/.gitignore
@@ -1,0 +1,2 @@
+/target/
+**/*.rs.bk

--- a/example-kernel/Cargo.lock
+++ b/example-kernel/Cargo.lock
@@ -1,0 +1,67 @@
+[[package]]
+name = "array-init"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bit_field"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "example-kernel"
+version = "0.1.0"
+dependencies = [
+ "x86_64 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nodrop"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "os_bootinfo"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "usize_conversions"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ux"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "x86_64"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "array-init 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit_field 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "os_bootinfo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "usize_conversions 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ux 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[metadata]
+"checksum array-init 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "23589ecb866b460d3a0f1278834750268c607e8e28a1b982c907219f3178cd72"
+"checksum bit_field 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed8765909f9009617974ab6b7d332625b320b33c326b1e9321382ef1999b5d56"
+"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
+"checksum os_bootinfo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "66481dbeb5e773e7bd85b63cd6042c30786f834338288c5ec4f3742673db360a"
+"checksum usize_conversions 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f70329e2cbe45d6c97a5112daad40c34cd9a4e18edb5a2a18fefeb584d8d25e5"
+"checksum ux 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53d8df5dd8d07fedccd202de1887d94481fadaea3db70479f459e8163a1fab41"
+"checksum x86_64 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b14609bad1c2c6a41113a1054f94394154e99bcb4b24cd7051109113c656c5a9"

--- a/example-kernel/Cargo.toml
+++ b/example-kernel/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "example-kernel"
+version = "0.1.0"
+authors = ["Philipp Oppermann <dev@phil-opp.com>"]
+edition = "2018"
+
+[dependencies]
+x86_64 = "0.3.4"

--- a/example-kernel/src/main.rs
+++ b/example-kernel/src/main.rs
@@ -1,0 +1,28 @@
+#![no_std] // don't link the Rust standard library
+#![no_main] // disable all Rust-level entry points
+
+use core::panic::PanicInfo;
+
+/// This function is called on panic.
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    loop {}
+}
+
+#[no_mangle] // don't mangle the name of this function
+pub extern "C" fn _start() -> ! {
+    // this function is the entry point, since the linker looks for a function
+    // named `_start` by default
+
+    // exit QEMU (see https://os.phil-opp.com/integration-tests/#shutting-down-qemu)
+    unsafe { exit_qemu(); }
+
+    loop {}
+}
+
+pub unsafe fn exit_qemu() {
+    use x86_64::instructions::port::Port;
+
+    let mut port = Port::<u32>::new(0xf4);
+    port.write(61); // exit code is (61 << 1) | 1 = 123
+}

--- a/example-kernel/x86_64-example-kernel.json
+++ b/example-kernel/x86_64-example-kernel.json
@@ -1,0 +1,15 @@
+{
+    "llvm-target": "x86_64-unknown-none",
+    "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+    "arch": "x86_64",
+    "target-endian": "little",
+    "target-pointer-width": "64",
+    "target-c-int-width": "32",
+    "os": "none",
+    "executables": true,
+    "linker-flavor": "ld.lld",
+    "linker": "rust-lld",
+    "panic-strategy": "abort",
+    "disable-redzone": true,
+    "features": "-mmx,-sse,+soft-float"
+  }


### PR DESCRIPTION
Fixes #32 

In addition to the tasks in #32, this also adds a small example kernel for testing the bootloader on travis.

cc @acheronfail