### PR TITLE
Fix context_switch spin jump

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ global_asm!(include_str!("video_mode/vga_320x200.s"));
 global_asm!(include_str!("video_mode/vga_text_80x25.s"));
 
 unsafe fn context_switch(boot_info: VirtAddr, entry_point: VirtAddr, stack_pointer: VirtAddr) -> ! {
-    asm!("jmp $1; .spin: jmp spin" :: "{rsp}"(stack_pointer), "r"(entry_point), "{rdi}"(boot_info) :: "intel");
+    asm!("jmp $1; context_switch_spin: jmp context_switch_spin" :: "{rsp}"(stack_pointer), "r"(entry_point), "{rdi}"(boot_info) :: "intel");
     ::core::hint::unreachable_unchecked()
 }
 


### PR DESCRIPTION
Fixes a small problem of #39: The problem is that inline Assembly has no special support for `.` labels, so `.spin` is just a global label with the name ".spin". But `jmp spin` jumps to the completely different "spin" label, which is defined somewhere in the assembly code. This PR fixes that problem by reintroducing the `context_switch_spin` label that was used in the assembly code before.