### PR TITLE
Only enable A20 if needed

### DIFF
--- a/src/stage_1.s
+++ b/src/stage_1.s
@@ -28,8 +28,13 @@ _start:
 enable_a20:
     # enable A20-Line via IO-Port 92, might not work on all motherboards
     in al, 0x92
+    test al, 2
+    jnz enable_a20_after
     or al, 2
+    and al, 0xFE
     out 0x92, al
+enable_a20_after:
+
 
 enter_protected_mode:
     # clear interrupts


### PR DESCRIPTION
Also avoid writing bit 0.

See https://www.win.tue.nl/~aeb/linux/kbd/A20.html

Fixes an issue reported in https://github.com/rust-osdev/bootloader/issues/44