### PR TITLE
Remove stabilized `try_from` feature

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 #![feature(lang_items)]
 #![feature(global_asm)]
-#![feature(try_from)]
 #![feature(step_trait)]
 #![feature(asm)]
 #![feature(nll)]


### PR DESCRIPTION
This is an obsoleted feature.

warning: the feature `try_from` has been stable since 1.34.0 and no longer requires an attribute to enable
 --> src/main.rs:3:12
  |
3 | #![feature(try_from)]
  |            ^^^^^^^^
  |
  = note: #[warn(stable_features)] on by default
