### PR TITLE
Version 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bootloader"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "fixedvec 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "font8x8 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["publish-lockfile"]
 
 [package]
 name = "bootloader"
-version = "0.5.3"
+version = "0.6.0"
 authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 license = "MIT/Apache-2.0"
 description = "An experimental pure-Rust x86 bootloader."

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,6 @@
-- Assert that the passed `KERNEL` executable exists for better error messages
+- Additional assertions for the passed `KERNEL` executable
+    - check that the executable exists (for better error messages)
+    - check that the executable has a non-empty text section (an empty text section occurs when no entry point is set)
 
 # 0.5.3
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,5 @@
+- Assert that the passed `KERNEL` executable exists for better error messages
+
 # 0.5.3
 
 - Mention minimal required bootimage version in error message when `KERNEL` environment variable is not set.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+## Breaking
+
+- Don't set the `#[cfg(not(test))]` attribute for the entry point function in the `entry_point` macro
+    - With custom test frameworks, it's possible to use the normal entry point also in test environments
+    - To get the old behavior, you can add the `#[cfg(not(test))]` attribute to the `entry_point` invocation
+
+## Other
+
 - Additional assertions for the passed `KERNEL` executable
     - check that the executable exists (for better error messages)
     - check that the executable has a non-empty text section (an empty text section occurs when no entry point is set)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,5 @@
+# 0.6.0
+
 ## Breaking
 
 - Don't set the `#[cfg(not(test))]` attribute for the entry point function in the `entry_point` macro

--- a/build.rs
+++ b/build.rs
@@ -27,6 +27,12 @@ fn main() {
         }
     });
 
+    // check that the kernel file exists
+    assert!(
+        kernel.exists(),
+        format!("KERNEL does not exist: {}", kernel.display())
+    );
+
     let kernel_file_name = kernel
         .file_name()
         .expect("KERNEL has no valid file name")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@ pub mod bootinfo;
 #[macro_export]
 macro_rules! entry_point {
     ($path:path) => {
-        #[cfg(not(test))]
         #[export_name = "_start"]
         pub extern "C" fn __impl_start(boot_info: &'static $crate::bootinfo::BootInfo) -> ! {
             // validate the signature of the program entry point


### PR DESCRIPTION
The main change of this PR is to remove the `#[cfg(not(test))]` attribute from the `entry_point` macro. This makes it possible to use the macro together with custom test frameworks and `cargo xtest`. Since this is a breaking change, this PR bumps the version to 0.6.0.

This PR also adds two additional checks to the build script:

- check that the kernel exists early to provide a better error message
- check that the kernel has a non-empty text section
  - an empty text section can occur if no entry point is set
  - this turns a runtime error (bootloader panics when loading the kernel) into a compile time error