### PR TITLE
Allow overriding the physical memory offset through an environment variable

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,5 @@
+- Make the physical memory offset configurable through a `BOOTLOADER_PHYSICAL_MEMORY_OFFSET` environment variable ([#58](https://github.com/rust-osdev/bootloader/pull/58)).
+
 # 0.6.0
 
 - **Breaking**: Don't set the `#[cfg(not(test))]` attribute for the entry point function in the `entry_point` macro

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The bootloader crate can be configured through some cargo features:
 - `vga_320x200`: This feature switches the VGA hardware to mode 0x13, a graphics mode with resolution 320x200 and 256 colors per pixel. The framebuffer is linear and lives at address `0xa0000`.
 - `recursive_page_table`: Maps the level 4 page table recursively and adds the [`recursive_page_table_address`](https://docs.rs/bootloader/0.4.0/bootloader/bootinfo/struct.BootInfo.html#structfield.recursive_page_table_addr) field to the passed `BootInfo`.
 - `map_physical_memory`: Maps the complete physical memory in the virtual address space and passes a [`physical_memory_offset`](https://docs.rs/bootloader/0.4.0/bootloader/bootinfo/struct.BootInfo.html#structfield.physical_memory_offset) field in the `BootInfo`.
+  - The virtual address where the physical memory should be mapped is configurable by setting the `BOOTLOADER_PHYSICAL_MEMORY_OFFSET` environment variable (supports decimal and hex numbers (prefixed with `0x`)).
 
 ## License
 

--- a/build.rs
+++ b/build.rs
@@ -128,11 +128,16 @@ fn main() {
     // create a file with the `PHYSICAL_MEMORY_OFFSET` constant
     let file_path = out_dir.join("physical_memory_offset.rs");
     let mut file = File::create(file_path).expect("failed to create physical_memory_offset.rs");
-    let physical_memory_offset = match option_env!("BOOTLOADER_PHYSICAL_MEMORY_OFFSET") {
-        None => 0o_177777_770_000_000_000_0000u64,
-        Some(s) => s.parse().expect(
-            "The `BOOTLOADER_PHYSICAL_MEMORY_OFFSET` environment variable must be an integer.",
+    let physical_memory_offset = match env::var("BOOTLOADER_PHYSICAL_MEMORY_OFFSET") {
+        Err(env::VarError::NotPresent) => 0o_177777_770_000_000_000_0000u64,
+        Err(env::VarError::NotUnicode(_)) => panic!(
+            "The `BOOTLOADER_PHYSICAL_MEMORY_OFFSET` environment variable must be valid unicode"
         ),
+        Ok(s) => s.parse().expect(&format!(
+            "The `BOOTLOADER_PHYSICAL_MEMORY_OFFSET` environment variable must be an\
+             integer (is `{}`).",
+            s
+        )),
     };
     file.write_all(
         format!(
@@ -151,6 +156,7 @@ fn main() {
     );
 
     println!("cargo:rerun-if-env-changed=KERNEL");
+    println!("cargo:rerun-if-env-changed=BOOTLOADER_PHYSICAL_MEMORY_OFFSET");
     println!("cargo:rerun-if-changed={}", kernel.display());
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/build.rs
+++ b/build.rs
@@ -133,9 +133,14 @@ fn main() {
         Err(env::VarError::NotUnicode(_)) => panic!(
             "The `BOOTLOADER_PHYSICAL_MEMORY_OFFSET` environment variable must be valid unicode"
         ),
-        Ok(s) => s.parse().expect(&format!(
-            "The `BOOTLOADER_PHYSICAL_MEMORY_OFFSET` environment variable must be an\
-             integer (is `{}`).",
+        Ok(s) => if s.starts_with("0x") {
+            u64::from_str_radix(&s[2..], 16)
+        } else {
+            u64::from_str_radix(&s, 10)
+        }
+        .expect(&format!(
+            "The `BOOTLOADER_PHYSICAL_MEMORY_OFFSET` environment variable must be an integer\
+             (is `{}`).",
             s
         )),
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,9 +22,9 @@ use x86_64::structures::paging::{
 use x86_64::ux::u9;
 use x86_64::{PhysAddr, VirtAddr};
 
-/// The offset into the virtual address space where the physical memory is mapped if
-/// the `map_physical_memory` is activated.
-const PHYSICAL_MEMORY_OFFSET: u64 = 0o_177777_770_000_000_000_0000;
+// The offset into the virtual address space where the physical memory is mapped if
+// the `map_physical_memory` is activated. Set by the build script.
+include!(concat!(env!("OUT_DIR"), "/physical_memory_offset.rs"));
 
 global_asm!(include_str!("stage_1.s"));
 global_asm!(include_str!("stage_2.s"));


### PR DESCRIPTION
The plan is that the `bootimage` crate gets an additional `Cargo.toml` config key for this property and sets the environment variable automatically.

cc @64