### PR TITLE
Remove stabilized publish-lockfile feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["publish-lockfile"]
-
 [package]
 name = "bootloader"
 version = "0.6.1"
@@ -7,7 +5,6 @@ authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 license = "MIT/Apache-2.0"
 description = "An experimental pure-Rust x86 bootloader."
 repository = "https://github.com/rust-osdev/bootloader"
-publish-lockfile = true
 edition = "2018"
 build = "build.rs"
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,5 @@
+- Remove stabilized publish-lockfile feature ([#62](https://github.com/rust-osdev/bootloader/pull/62))
+
 # 0.6.1
 
 - Make the physical memory offset configurable through a `BOOTLOADER_PHYSICAL_MEMORY_OFFSET` environment variable ([#58](https://github.com/rust-osdev/bootloader/pull/58)).


### PR DESCRIPTION
The feature was stabilized/removed in https://github.com/rust-lang/cargo/pull/7026. Now all binaries include the Cargo.lock by default.

Fixes #57