### PR TITLE
Only include dependencies when `binary` feature is enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ repository = "https://github.com/rust-osdev/bootloader"
 edition = "2018"
 build = "build.rs"
 
+[[bin]]
+name = "bootloader"
+required-features = ["binary"]
+
 [dependencies]
 xmas-elf = { version = "0.6.2", optional = true }
 x86_64 = { version = "0.7.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,11 @@ features = ["unicode"]
 optional = true
 
 [build-dependencies]
-llvm-tools = "0.1"
+llvm-tools = { version = "0.1", optional = true }
 
 [features]
 default = []
-binary = ["xmas-elf", "x86_64", "usize_conversions", "fixedvec"]
+binary = ["xmas-elf", "x86_64", "usize_conversions", "fixedvec", "llvm-tools"]
 vga_320x200 = ["font8x8"]
 recursive_page_table = []
 map_physical_memory = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ edition = "2018"
 build = "build.rs"
 
 [dependencies]
-xmas-elf = "0.6.2"
-x86_64 = "0.7.2"
-usize_conversions = "0.2.0"
-fixedvec = "0.2.3"
+xmas-elf = { version = "0.6.2", optional = true }
+x86_64 = { version = "0.7.2", optional = true }
+usize_conversions = { version = "0.2.0", optional = true }
+fixedvec = { version = "0.2.3", optional = true }
 
 [dependencies.font8x8]
 version = "0.2.4"
@@ -25,6 +25,7 @@ llvm-tools = "0.1"
 
 [features]
 default = []
+binary = ["xmas-elf", "x86_64", "usize_conversions", "fixedvec"]
 vga_320x200 = ["font8x8"]
 recursive_page_table = []
 map_physical_memory = []

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ As an example, you can build the bootloader with example kernel from the `exampl
 cd example-kernel
 cargo xbuild
 cd ..
-KERNEL=example-kernel/target/x86_64-example-kernel/debug/example-kernel cargo xbuild --release
+KERNEL=example-kernel/target/x86_64-example-kernel/debug/example-kernel cargo xbuild --release --features binary
 ```
 
-This results in a bootloader executable at `target/x86_64-bootloader.json/release/bootloader`. This executable is still an ELF file, which can't be run directly.
+The `binary` feature is required to enable the dependencies required for compiling the bootloader executable. The command results in a bootloader executable at `target/x86_64-bootloader.json/release/bootloader`. This executable is still an ELF file, which can't be run directly.
 
 ## Run
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,7 @@ steps:
   workingDirectory: test-kernel
   displayName: 'Build Test Kernel'
 
-- script: cargo xbuild --release
+- script: cargo xbuild --bin bootloader --features binary --release
   displayName: 'Build Bootloader'
   env: { KERNEL: "test-kernel/target/x86_64-test-kernel/debug/test-kernel" }
 

--- a/build.rs
+++ b/build.rs
@@ -1,19 +1,23 @@
-use std::{
-    env,
-    fs::File,
-    io::Write,
-    path::{Path, PathBuf},
-    process::{self, Command},
-};
+#[cfg(not(feature = "binary"))]
+fn main() {}
 
+#[cfg(feature = "binary")]
 fn main() {
+    use std::{
+        env,
+        fs::File,
+        io::Write,
+        path::{Path, PathBuf},
+        process::{self, Command},
+    };
+
     let target = env::var("TARGET").expect("TARGET not set");
     if Path::new(&target)
         .file_stem()
         .expect("target has no file stem")
         != "x86_64-bootloader"
     {
-        return;
+        panic!("The bootloader must be compiled for the `x86_64-bootloader.json` target.");
     }
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));


### PR DESCRIPTION
This change vastly improves compile times when only `lib.rs` is compiled because no dependencies need to be compiled in this case. See https://github.com/rust-lang/cargo/issues/1982#issuecomment-319661478 for more information about the approach.

This is a **breaking change** since a build of the executable without the `binary` feature will result in an error.

Depends on https://github.com/rust-osdev/bootimage/pull/43, so we will need to increase the minimally supported bootimage version. To avoid public breakage, we should probably wait a bit after releasing the new bootimage version to give people time to upgrade.