### PR TITLE
Dynamically map kernel stack, boot info, physical memory and recursive table

### DIFF
--- a/src/level4_entries.rs
+++ b/src/level4_entries.rs
@@ -21,7 +21,7 @@ impl UsedLevel4Entries {
             let end_page: Page =
                 Page::containing_address(VirtAddr::new(segment.virtual_addr + segment.mem_size));
 
-            for p4_index in u64::from(start_page.p4_index())..u64::from(end_page.p4_index()) {
+            for p4_index in u64::from(start_page.p4_index())..=u64::from(end_page.p4_index()) {
                 used.entry_state[p4_index as usize] = true;
             }
         }

--- a/src/level4_entries.rs
+++ b/src/level4_entries.rs
@@ -1,0 +1,43 @@
+use core::convert::TryInto;
+use fixedvec::FixedVec;
+use x86_64::ux;
+use x86_64::{structures::paging::Page, VirtAddr};
+use xmas_elf::program::ProgramHeader64;
+
+pub struct UsedLevel4Entries {
+    entry_state: [bool; 512], // whether an entry is in use by the kernel
+}
+
+impl UsedLevel4Entries {
+    pub fn new(segments: &FixedVec<ProgramHeader64>) -> Self {
+        let mut used = UsedLevel4Entries {
+            entry_state: [false; 512],
+        };
+
+        used.entry_state[0] = true; // TODO: Can we do this dynamically?
+
+        for segment in segments {
+            let start_page: Page = Page::containing_address(VirtAddr::new(segment.virtual_addr));
+            let end_page: Page =
+                Page::containing_address(VirtAddr::new(segment.virtual_addr + segment.mem_size));
+
+            for p4_index in u64::from(start_page.p4_index())..u64::from(end_page.p4_index()) {
+                used.entry_state[p4_index as usize] = true;
+            }
+        }
+
+        used
+    }
+
+    pub fn get_free_entry(&mut self) -> ux::u9 {
+        let (idx, entry) = self
+            .entry_state
+            .iter_mut()
+            .enumerate()
+            .find(|(_, &mut entry)| entry == false)
+            .expect("no usable level 4 entries found");
+
+        *entry = true;
+        ux::u9::new(idx.try_into().unwrap())
+    }
+}

--- a/src/page_table.rs
+++ b/src/page_table.rs
@@ -1,5 +1,4 @@
 use crate::frame_allocator::FrameAllocator;
-use crate::level4_entries::UsedLevel4Entries;
 use bootloader::bootinfo::MemoryRegionType;
 use fixedvec::FixedVec;
 use x86_64::structures::paging::mapper::{MapToError, MapperFlush, UnmapError};
@@ -22,13 +21,13 @@ pub(crate) fn map_kernel(
 
     // Create a stack
     let stack_size: u64 = 512; // in pages
+    let stack_start = stack_start + 1; // Leave the first page unmapped as a 'guard page'
     let stack_end = stack_start + stack_size;
 
     let flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE;
     let region_type = MemoryRegionType::KernelStack;
 
-    // Leave the first page unmapped as a 'guard page'
-    for page in Page::range(stack_start + 1, stack_end) {
+    for page in Page::range(stack_start, stack_end) {
         let frame = frame_allocator
             .allocate_frame(region_type)
             .ok_or(MapToError::FrameAllocationFailed)?;

--- a/src/stage_3.s
+++ b/src/stage_3.s
@@ -36,9 +36,6 @@ set_up_page_tables:
     rep stosd
 
     # p4
-    lea eax, [_p4]
-    or eax, (1 | 2)
-    mov [_p4 + 511 * 8], eax # recursive mapping
     lea eax, [_p3]
     or eax, (1 | 2)
     mov [_p4], eax
@@ -63,10 +60,12 @@ set_up_page_tables:
     cmp ecx, edx
     jb map_p2_table
     # p1
-    lea eax, __bootloader_start
+    # start mapping from __page_table_start, as we need to be able to access
+    # the p4 table from rust. stop mapping at __bootloader_end
+    lea eax, __page_table_start
     and eax, 0xfffff000
     or eax, (1 | 2)
-    lea ecx, __bootloader_start
+    lea ecx, __page_table_start
     shr ecx, 12 # start page number
     lea edx, __bootloader_end
     add edx, 4096 - 1 # align up


### PR DESCRIPTION
Fixes #61. This provides a way for the user to set the kernel stack address through an environment variable, or calculate it dynamically, making sure that it does not interfere with any other mappings. We also calculate space for the recursive page table, boot info and physical memory offset, with the small optimisation that the boot info and kernel stack are placed adjacently if possible to save a few extra page table allocations.

Going to punt on a way to unmap these things for now. Reclaiming memory from unused page tables is a bit tricky and it would be nice to do it right.