### PR TITLE
Configurable kernel stack size, better non-x86_64 errors

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,13 @@
 #[cfg(not(feature = "binary"))]
-#[allow(unreachable_code)]
 fn main() {
     #[cfg(target_arch = "x86")]
-    panic!("This crate currently does not support 32-bit protected mode. \
-    See https://github.com/rust-osdev/bootloader/issues/70 for more information.");
+    compile_error!(
+        "This crate currently does not support 32-bit protected mode. \
+         See https://github.com/rust-osdev/bootloader/issues/70 for more information."
+    );
 
-    #[cfg(not(target_arch = "x86_64"))]
-    panic!("This crate only supports the x86_64 architecture.");
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
+    compile_error!("This crate only supports the x86_64 architecture.");
 }
 
 #[cfg(feature = "binary")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,12 +24,14 @@ use x86_64::structures::paging::{
 use x86_64::ux::u9;
 use x86_64::{PhysAddr, VirtAddr};
 
-// The offset into the virtual address space where the physical memory is mapped if
-// the `map_physical_memory` is activated. Set by the build script.
-include!(concat!(env!("OUT_DIR"), "/physical_memory_offset.rs"));
-
-// The virtual address of the kernel stack. Set by the build script.
-include!(concat!(env!("OUT_DIR"), "/kernel_stack_address.rs"));
+// The bootloader_config.rs file contains some configuration constants set by the build script:
+// PHYSICAL_MEMORY_OFFSET: The offset into the virtual address space where the physical memory 
+// is mapped if the `map_physical_memory` feature is activated.
+//
+// KERNEL_STACK_ADDRESS: The virtual address of the kernel stack.
+//
+// KERNEL_STACK_SIZE: The number of pages in the kernel stack.
+include!(concat!(env!("OUT_DIR"), "/bootloader_config.rs"));
 
 global_asm!(include_str!("stage_1.s"));
 global_asm!(include_str!("stage_2.s"));
@@ -271,6 +273,7 @@ fn load_elf(
     let stack_end = page_table::map_kernel(
         kernel_start.phys(),
         kernel_stack_address,
+        KERNEL_STACK_SIZE,
         &segments,
         &mut rec_page_table,
         &mut frame_allocator,

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ use x86_64::ux::u9;
 use x86_64::{PhysAddr, VirtAddr};
 
 // The bootloader_config.rs file contains some configuration constants set by the build script:
-// PHYSICAL_MEMORY_OFFSET: The offset into the virtual address space where the physical memory 
+// PHYSICAL_MEMORY_OFFSET: The offset into the virtual address space where the physical memory
 // is mapped if the `map_physical_memory` feature is activated.
 //
 // KERNEL_STACK_ADDRESS: The virtual address of the kernel stack.

--- a/src/page_table.rs
+++ b/src/page_table.rs
@@ -11,6 +11,7 @@ use xmas_elf::program::{self, ProgramHeader64};
 pub(crate) fn map_kernel(
     kernel_start: PhysAddr,
     stack_start: Page,
+    stack_size: u64,
     segments: &FixedVec<ProgramHeader64>,
     page_table: &mut RecursivePageTable,
     frame_allocator: &mut FrameAllocator,
@@ -20,9 +21,8 @@ pub(crate) fn map_kernel(
     }
 
     // Create a stack
-    let stack_size: u64 = 512; // in pages
     let stack_start = stack_start + 1; // Leave the first page unmapped as a 'guard page'
-    let stack_end = stack_start + stack_size;
+    let stack_end = stack_start + stack_size; // stack_size is in pages
 
     let flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE;
     let region_type = MemoryRegionType::KernelStack;


### PR DESCRIPTION
Allows the configuration of the kernel stack size through an environment variable.

Also makes the errors a bit nicer if you try to use this crate from a non-x86_64 architecture (only works if you build it as a library), as discussed in #70.