### PR TITLE
Parse bootloader configuration from kernel's Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,7 @@ dependencies = [
  "fixedvec 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "font8x8 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "llvm-tools 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "usize_conversions 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "x86_64 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "xmas-elf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -54,6 +55,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "nodrop"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "toml"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "usize_conversions"
@@ -99,6 +113,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum font8x8 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "44226c40489fb1d602344a1d8f1b544570c3435e396dda1eda7b5ef010d8f1be"
 "checksum llvm-tools 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "955be5d0ca0465caf127165acb47964f911e2bc26073e865deb8be7189302faf"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
+"checksum serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5626ac617da2f2d9c48af5515a21d5a480dbd151e01bb1c355e26a3e68113"
+"checksum toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b8c96d7873fa7ef8bdeb3a9cda3ac48389b4154f32b9803b4bc26220b677b039"
 "checksum usize_conversions 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f70329e2cbe45d6c97a5112daad40c34cd9a4e18edb5a2a18fefeb584d8d25e5"
 "checksum ux 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "88dfeb711b61ce620c0cb6fd9f8e3e678622f0c971da2a63c4b3e25e88ed012f"
 "checksum x86_64 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1ad37c1665071808d64e65f7cdae32afcdc90fd7ae7fa402bbda36b824f1add6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,11 @@ optional = true
 
 [build-dependencies]
 llvm-tools = { version = "0.1", optional = true }
+toml = { version = "0.5.1", optional = true }
 
 [features]
 default = []
-binary = ["xmas-elf", "x86_64", "usize_conversions", "fixedvec", "llvm-tools"]
+binary = ["xmas-elf", "x86_64", "usize_conversions", "fixedvec", "llvm-tools", "toml"]
 vga_320x200 = ["font8x8"]
 recursive_page_table = []
 map_physical_memory = []

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You need a nightly [Rust](https://www.rust-lang.org) compiler and [cargo xbuild]
 
 ## Build
 
-The simplest way to use the bootloader is in combination with the [bootimage](https://github.com/rust-osdev/bootimage) tool. This crate **requires at least bootimage PLACEHOLDER**. With the tool installed, you can add a normal cargo dependency on the `bootloader` crate to your kernel and then run `bootimage build` to create a bootable disk image. You can also execute `bootimage run` to run your kernel in [QEMU](https://www.qemu.org/) (needs to be installed).
+The simplest way to use the bootloader is in combination with the [bootimage](https://github.com/rust-osdev/bootimage) tool. This crate **requires at least bootimage 0.7.7**. With the tool installed, you can add a normal cargo dependency on the `bootloader` crate to your kernel and then run `bootimage build` to create a bootable disk image. You can also execute `bootimage run` to run your kernel in [QEMU](https://www.qemu.org/) (needs to be installed).
 
 To compile the bootloader manually, you need to invoke `cargo xbuild` with two environment variables:
 * `KERNEL`: points to your kernel executable (in the ELF format)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -96,7 +96,9 @@ steps:
 
 - script: cargo xbuild --bin bootloader --features binary --release
   displayName: 'Build Bootloader'
-  env: { KERNEL: "test-kernel/target/x86_64-test-kernel/debug/test-kernel" }
+  env:
+    KERNEL: "test-kernel/target/x86_64-test-kernel/debug/test-kernel"
+    KERNEL_MANIFEST: "test-kernel/Cargo.toml"
 
 - script: cargo objcopy -- -I elf64-x86-64 -O binary --binary-architecture=i386:x86-64 target/x86_64-bootloader/release/bootloader target/x86_64-bootloader/release/bootloader.bin
   displayName: 'Convert Bootloader ELF to Binary'

--- a/build.rs
+++ b/build.rs
@@ -60,13 +60,17 @@ fn parse_to_config(cfg: &mut BootloaderConfig, table: &toml::value::Table) {
             }
             ("physical-memory-offset", Value::String(s)) => {
                 #[cfg(feature = "map_physical_memory")]
-                cfg.physical_memory_offset = Some(parse_aligned_addr(key.as_str(), &s));
+                {
+                    cfg.physical_memory_offset = Some(parse_aligned_addr(key.as_str(), &s));
+                }
 
                 #[cfg(not(feature = "map_physical_memory"))]
-                panic!(
-                    "`physical-memory-offset` is only supported when the `map_physical_memory` \
-                     feature of the crate is enabled"
-                );
+                {
+                    panic!(
+                        "`physical-memory-offset` is only supported when the `map_physical_memory` \
+                         feature of the crate is enabled"
+                    );
+                }
             }
             ("kernel-stack-size", Value::Integer(i)) => {
                 if i <= 0 {

--- a/build.rs
+++ b/build.rs
@@ -59,7 +59,14 @@ fn parse_to_config(cfg: &mut BootloaderConfig, table: &toml::value::Table) {
                 cfg.kernel_stack_address = Some(parse_aligned_addr(key.as_str(), &s));
             }
             ("physical-memory-offset", Value::String(s)) => {
+                #[cfg(feature = "map_physical_memory")]
                 cfg.physical_memory_offset = Some(parse_aligned_addr(key.as_str(), &s));
+
+                #[cfg(not(feature = "map_physical_memory"))]
+                panic!(
+                    "`physical-memory-offset` is only supported when the `map_physical_memory` \
+                     feature of the crate is enabled"
+                );
             }
             ("kernel-stack-size", Value::Integer(i)) => {
                 if i <= 0 {

--- a/build.rs
+++ b/build.rs
@@ -10,35 +10,71 @@ fn main() {
     compile_error!("This crate only supports the x86_64 architecture.");
 }
 
+#[derive(Default)]
+struct BootloaderConfig {
+    physical_memory_offset: Option<u64>,
+    kernel_stack_address: Option<u64>,
+    kernel_stack_size: Option<u64>,
+}
+
 #[cfg(feature = "binary")]
-fn num_from_env(env: &'static str, aligned: bool) -> Option<u64> {
-    use std::env;
-    match env::var(env) {
-        Err(env::VarError::NotPresent) => None,
-        Err(env::VarError::NotUnicode(_)) => {
-            panic!("The `{}` environment variable must be valid unicode", env,)
-        }
-        Ok(s) => {
-            let num = if s.starts_with("0x") {
-                u64::from_str_radix(&s[2..], 16)
-            } else {
-                u64::from_str_radix(&s, 10)
-            };
+fn parse_aligned_addr(key: &str, value: &str) -> u64 {
+    let num = if value.starts_with("0x") {
+        u64::from_str_radix(&value[2..], 16)
+    } else {
+        u64::from_str_radix(&value, 10)
+    };
 
-            let num = num.expect(&format!(
-                "The `{}` environment variable must be an integer\
-                 (is `{}`).",
-                env, s
-            ));
+    let num = num.expect(&format!(
+        "`{}` in the kernel manifest must be an integer (is `{}`)",
+        key, value
+    ));
 
-            if aligned && num % 0x1000 != 0 {
+    if num % 0x1000 != 0 {
+        panic!(
+            "`{}` in the kernel manifest must be aligned to 4KiB (is `{}`)",
+            key, value
+        );
+    } else {
+        num
+    }
+}
+
+#[cfg(feature = "binary")]
+fn parse_to_config(cfg: &mut BootloaderConfig, table: &toml::value::Table) {
+    use toml::Value;
+
+    for (key, value) in table {
+        match (key.as_str(), value.clone()) {
+            ("kernel-stack-address", Value::Integer(i))
+            | ("physical-memory-offset", Value::Integer(i)) => {
                 panic!(
-                    "The `{}` environment variable must be aligned to 0x1000 (is `{:#x}`).",
-                    env, num
+                    "`{0}` in the kernel manifest must be given as a string, \
+                     as toml does not support unsigned 64-bit integers (try `{0} = \"{1}\"`)",
+                    key.as_str(),
+                    i
                 );
             }
-
-            Some(num)
+            ("kernel-stack-address", Value::String(s)) => {
+                cfg.kernel_stack_address = Some(parse_aligned_addr(key.as_str(), &s));
+            }
+            ("physical-memory-offset", Value::String(s)) => {
+                cfg.physical_memory_offset = Some(parse_aligned_addr(key.as_str(), &s));
+            }
+            ("kernel-stack-size", Value::Integer(i)) => {
+                if i <= 0 {
+                    panic!("`kernel-stack-size` in kernel manifest must be positive");
+                } else {
+                    cfg.kernel_stack_size = Some(i as u64);
+                }
+            }
+            (s, _) => {
+                panic!(
+                    "unknown key '{}' in kernel manifest \
+                     - you may need to update the bootloader crate",
+                    s
+                );
+            }
         }
     }
 }
@@ -47,11 +83,12 @@ fn num_from_env(env: &'static str, aligned: bool) -> Option<u64> {
 fn main() {
     use std::{
         env,
-        fs::File,
+        fs::{self, File},
         io::Write,
         path::{Path, PathBuf},
         process::{self, Command},
     };
+    use toml::Value;
 
     let target = env::var("TARGET").expect("TARGET not set");
     if Path::new(&target)
@@ -185,22 +222,55 @@ fn main() {
         process::exit(1);
     }
 
+    // Parse the kernel's Cargo.toml which is given to us by bootimage
+    let mut bootloader_config = BootloaderConfig::default();
+
+    match env::var("KERNEL_MANIFEST") {
+        Err(env::VarError::NotPresent) => {
+            panic!("The KERNEL_MANIFEST environment variable must be set for building the bootloader.\n\n\
+                 If you use `bootimage` for building you need at least version PLACEHOLDER. You can \
+                 update `bootimage` by running `cargo install bootimage --force`.");
+        }
+        Err(env::VarError::NotUnicode(_)) => {
+            panic!("The KERNEL_MANIFEST environment variable contains invalid unicode")
+        }
+        Ok(path) => {
+            println!("cargo:rerun-if-changed={}", path);
+
+            let contents = fs::read_to_string(&path).expect(&format!(
+                "failed to read kernel manifest file (path: {})",
+                path
+            ));
+
+            let manifest = contents
+                .parse::<Value>()
+                .expect("failed to parse kernel's Cargo.toml");
+
+            let table = manifest
+                .get("package")
+                .and_then(|table| table.get("metadata"))
+                .and_then(|table| table.get("bootloader"))
+                .and_then(|table| table.as_table());
+
+            if let Some(table) = table {
+                parse_to_config(&mut bootloader_config, table);
+            }
+        }
+    }
+
     // Configure constants for the bootloader
     // We leave some variables as Option<T> rather than hardcoding their defaults so that they
     // can be calculated dynamically by the bootloader.
     let file_path = out_dir.join("bootloader_config.rs");
     let mut file = File::create(file_path).expect("failed to create bootloader_config.rs");
-    let physical_memory_offset = num_from_env("BOOTLOADER_PHYSICAL_MEMORY_OFFSET", true);
-    let kernel_stack_address = num_from_env("BOOTLOADER_KERNEL_STACK_ADDRESS", true);
-    let kernel_stack_size = num_from_env("BOOTLOADER_KERNEL_STACK_SIZE", false);
     file.write_all(
         format!(
             "const PHYSICAL_MEMORY_OFFSET: Option<u64> = {:?};
             const KERNEL_STACK_ADDRESS: Option<u64> = {:?};
             const KERNEL_STACK_SIZE: u64 = {};",
-            physical_memory_offset,
-            kernel_stack_address,
-            kernel_stack_size.unwrap_or(512), // size is in number of pages
+            bootloader_config.physical_memory_offset,
+            bootloader_config.kernel_stack_address,
+            bootloader_config.kernel_stack_size.unwrap_or(512), // size is in number of pages
         )
         .as_bytes(),
     )
@@ -214,9 +284,7 @@ fn main() {
     );
 
     println!("cargo:rerun-if-env-changed=KERNEL");
-    println!("cargo:rerun-if-env-changed=BOOTLOADER_PHYSICAL_MEMORY_OFFSET");
-    println!("cargo:rerun-if-env-changed=BOOTLOADER_KERNEL_STACK_ADDRESS");
-    println!("cargo:rerun-if-env-changed=BOOTLOADER_KERNEL_STACK_SIZE");
+    println!("cargo:rerun-if-env-changed=KERNEL_MANIFEST");
     println!("cargo:rerun-if-changed={}", kernel.display());
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/build.rs
+++ b/build.rs
@@ -239,7 +239,7 @@ fn main() {
     match env::var("KERNEL_MANIFEST") {
         Err(env::VarError::NotPresent) => {
             panic!("The KERNEL_MANIFEST environment variable must be set for building the bootloader.\n\n\
-                 If you use `bootimage` for building you need at least version PLACEHOLDER. You can \
+                 If you use `bootimage` for building you need at least version 0.7.7. You can \
                  update `bootimage` by running `cargo install bootimage --force`.");
         }
         Err(env::VarError::NotUnicode(_)) => {


### PR DESCRIPTION
As discussed in https://github.com/rust-osdev/bootimage/pull/44.

Requires support from the `bootimage` crate (so it knows where to find the kernel's `Cargo.toml`), and is also a breaking change as it removes support for the old environment variable `BOOTLOADER_PHYSICAL_MEMORY_OFFSET`.