### PR TITLE
Change the way the kernel entry point is called to honor alignement ABI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ global_asm!(include_str!("video_mode/vga_320x200.s"));
 global_asm!(include_str!("video_mode/vga_text_80x25.s"));
 
 unsafe fn context_switch(boot_info: VirtAddr, entry_point: VirtAddr, stack_pointer: VirtAddr) -> ! {
-    asm!("jmp $1; ${:private}.spin.${:uid}: jmp ${:private}.spin.${:uid}" ::
+    asm!("call $1; ${:private}.spin.${:uid}: jmp ${:private}.spin.${:uid}" ::
          "{rsp}"(stack_pointer), "r"(entry_point), "{rdi}"(boot_info) :: "intel");
     ::core::hint::unreachable_unchecked()
 }


### PR DESCRIPTION
Compilers expect functions to be called with the stack containing the return address making the rsp be 8 mod 16. jmp caused rsp to be 0 mod 16 (aka 16 bytes aligned), which then caused compiler to meke the stack misaligned everywhere.

Fix #80 