### PR TITLE
remove unnecessary extern C on panic handler to fix not-ffi-safe warning

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -365,7 +365,7 @@ fn enable_write_protect_bit() {
 
 #[panic_handler]
 #[no_mangle]
-pub extern "C" fn panic(info: &PanicInfo) -> ! {
+pub fn panic(info: &PanicInfo) -> ! {
     use core::fmt::Write;
     write!(printer::Printer, "{}", info).unwrap();
     loop {}


### PR DESCRIPTION
1.40.0-nightly has added a warning about extern functions that are not ffi-safe.
the panic handler is unnecessarily marked as extern and trips this warning.
this pull request removes the extern decleration to fix the warning.

```
Building bootloader
   Compiling bootloader v0.8.2 (/Users/cmsd2/.cargo/registry/src/github.com-1ecc6299db9ec823/bootloader-0.8.2)
warning: `extern` fn uses type `core::panic::PanicInfo`, which is not FFI-safe
   --> src/main.rs:368:31
    |
368 | pub extern "C" fn panic(info: &PanicInfo) -> ! {
    |                               ^^^^^^^^^^ not FFI-safe
```

Fixes #84