### PR TITLE
Move architecture checks from build script into lib.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,14 +1,5 @@
 #[cfg(not(feature = "binary"))]
-fn main() {
-    #[cfg(target_arch = "x86")]
-    compile_error!(
-        "This crate currently does not support 32-bit protected mode. \
-         See https://github.com/rust-osdev/bootloader/issues/70 for more information."
-    );
-
-    #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
-    compile_error!("This crate only supports the x86_64 architecture.");
-}
+fn main() {}
 
 #[cfg(feature = "binary")]
 #[derive(Default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,15 @@ pub use crate::bootinfo::BootInfo;
 
 pub mod bootinfo;
 
+#[cfg(target_arch = "x86")]
+compile_error!(
+    "This crate currently does not support 32-bit protected mode. \
+         See https://github.com/rust-osdev/bootloader/issues/70 for more information."
+);
+
+#[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
+compile_error!("This crate only supports the x86_64 architecture.");
+
 /// Defines the entry point function.
 ///
 /// The function must have the signature `fn(&'static BootInfo) -> !`.


### PR DESCRIPTION
The build script always gets compiled for the host platform, so it only checked that the _host_ was `x86_64`. With the check in lib.rs, we correctly verify that the target is `x86_64`.

Fixes #90 