### PR TITLE
Add basic support for ELF thread local storage segments

### DIFF
--- a/src/bootinfo/mod.rs
+++ b/src/bootinfo/mod.rs
@@ -42,6 +42,7 @@ pub struct BootInfo {
     /// can be safely accessed.
     #[cfg(feature = "map_physical_memory")]
     pub physical_memory_offset: u64,
+    tls_template: TlsTemplate,
     _non_exhaustive: u8, // `()` is not FFI safe
 }
 
@@ -51,11 +52,18 @@ impl BootInfo {
     #[doc(hidden)]
     pub fn new(
         memory_map: MemoryMap,
+        tls_template: Option<TlsTemplate>,
         recursive_page_table_addr: u64,
         physical_memory_offset: u64,
     ) -> Self {
+        let tls_template = tls_template.unwrap_or(TlsTemplate {
+            start_addr: 0,
+            file_size: 0,
+            mem_size: 0,
+        });
         BootInfo {
             memory_map,
+            tls_template,
             #[cfg(feature = "recursive_page_table")]
             recursive_page_table_addr,
             #[cfg(feature = "map_physical_memory")]
@@ -63,6 +71,42 @@ impl BootInfo {
             _non_exhaustive: 0,
         }
     }
+
+    /// Returns information about the thread local storage segment of the kernel.
+    ///
+    /// Returns `None` if the kernel has no thread local storage segment.
+    ///
+    /// (The reason this is a method instead of a normal field is that `Option`
+    /// is not FFI-safe.)
+    pub fn tls_template(&self) -> Option<TlsTemplate> {
+        if self.tls_template.mem_size > 0 {
+            Some(self.tls_template)
+        } else {
+            None
+        }
+    }
+}
+
+/// Information about the thread local storage (TLS) template.
+///
+/// This template can be used to set up thread local storage for threads. For
+/// each thread, a new memory location of size `mem_size` must be initialized.
+/// Then the first `file_size` bytes of this template needs to be copied to the
+/// location. The additional `mem_size - file_size` bytes must be initialized with
+/// zero.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub struct TlsTemplate {
+    /// The virtual start address of the thread local storage template.
+    pub start_addr: u64,
+    /// The number of data bytes in the template.
+    ///
+    /// Corresponds to the length of the `.tdata` section.
+    pub file_size: u64,
+    /// The total number of bytes that the TLS segment should have in memory.
+    ///
+    /// Corresponds to the combined length of the `.tdata` and `.tbss` sections.
+    pub mem_size: u64,
 }
 
 extern "C" {

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,7 +271,7 @@ fn bootloader_main(
     };
 
     // Map kernel segments.
-    let stack_end = page_table::map_kernel(
+    let kernel_memory_info = page_table::map_kernel(
         kernel_start.phys(),
         kernel_stack_address,
         KERNEL_STACK_SIZE,
@@ -324,6 +324,7 @@ fn bootloader_main(
     // Construct boot info structure.
     let mut boot_info = BootInfo::new(
         memory_map,
+        kernel_memory_info.tls_segment,
         recursive_page_table_addr.as_u64(),
         physical_memory_offset,
     );
@@ -352,7 +353,7 @@ fn bootloader_main(
     sse::enable_sse();
 
     let entry_point = VirtAddr::new(entry_point);
-    unsafe { context_switch(boot_info_addr, entry_point, stack_end) };
+    unsafe { context_switch(boot_info_addr, entry_point, kernel_memory_info.stack_end) };
 }
 
 fn enable_nxe_bit() {


### PR DESCRIPTION
This reports the thread local storage segment of the kernel (if present) in the boot information. This should make it possible to use the unstable [`#[thread_local]` attribute](https://github.com/rust-lang/rust/issues/29594). Since the TLS template overlaps with parts of a LOAD segment, no additional mapping needs to be done.

Note that the TLS template should not be used directly. Instead, the kernel should create a copy the TLS template for each thread and then set up the `fs` register accordingly. See https://uclibc.org/docs/tls.pdf for more information.

This code only works for a single TLS segment. If more than one TLS segment are present in the executable, the bootloader errors. We can of course lift this restriction if this becomes a problem in practice.

Fixes #95 
