### PR TITLE
Add boilerplate for a page aligned SMP trampoline function

### DIFF
--- a/linker.ld
+++ b/linker.ld
@@ -25,13 +25,17 @@ SECTIONS {
     . = 0x7c00;
     _stack_end = .;
 
-    .bootloader :
+    .bootloader_first_stage :
     {
         /* first stage */
         *(.boot-first-stage)
+    }
 
+    .bootloader :
+    {
         /* rest of bootloader */
         _rest_of_bootloader_start_addr = .;
+        *(.smp_trampoline)
         *(.boot)
         *(.context_switch)
         *(.text .text.*)

--- a/src/bootinfo/mod.rs
+++ b/src/bootinfo/mod.rs
@@ -29,6 +29,7 @@ pub struct BootInfo {
     /// the memory map before passing it to the kernel. Regions marked as usable can be freely
     /// used by the kernel.
     pub memory_map: MemoryMap,
+    pub smp_trampoline: unsafe extern "C" fn() -> !,
     /// The virtual address of the recursively mapped level 4 page table.
     #[cfg(feature = "recursive_page_table")]
     pub recursive_page_table_addr: u64,
@@ -51,11 +52,13 @@ impl BootInfo {
     #[doc(hidden)]
     pub fn new(
         memory_map: MemoryMap,
+        smp_trampoline: unsafe extern "C" fn() -> !,
         recursive_page_table_addr: u64,
         physical_memory_offset: u64,
     ) -> Self {
         BootInfo {
             memory_map,
+            smp_trampoline,
             #[cfg(feature = "recursive_page_table")]
             recursive_page_table_addr,
             #[cfg(feature = "map_physical_memory")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ global_asm!(include_str!("stage_1.s"));
 global_asm!(include_str!("stage_2.s"));
 global_asm!(include_str!("e820.s"));
 global_asm!(include_str!("stage_3.s"));
+global_asm!(include_str!("smp_trampoline.s"));
 
 #[cfg(feature = "vga_320x200")]
 global_asm!(include_str!("video_mode/vga_320x200.s"));
@@ -84,6 +85,7 @@ extern "C" {
     static __bootloader_end: usize;
     static __bootloader_start: usize;
     static _p4: usize;
+    fn _smp_trampoline() -> !;
 }
 
 #[no_mangle]
@@ -324,6 +326,7 @@ fn bootloader_main(
     // Construct boot info structure.
     let mut boot_info = BootInfo::new(
         memory_map,
+        _smp_trampoline,
         recursive_page_table_addr.as_u64(),
         physical_memory_offset,
     );

--- a/src/smp_trampoline.s
+++ b/src/smp_trampoline.s
@@ -1,0 +1,8 @@
+.section .smp_trampoline, "awx"
+.global _smp_trampoline
+.intel_syntax noprefix
+.align 4096
+.code16
+
+_smp_trampoline:
+    jmp _smp_trampoline


### PR DESCRIPTION
This code crates a page aligned `smp_trampoline` function that lives in the first megabyte and exports its address in the boot information. According to https://github.com/rust-osdev/bootloader/issues/74, it should be possible to implement a SMP trampoline function using these building blocks.