### PR TITLE
Implement boot-info-address

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ kernel-stack-size = 128
 # Only applies if the `map_physical_memory` feature of the crate is enabled.
 # If not provided, the bootloader dynamically searches for a location.
 physical-memory-offset = "0xFFFF800000000000"
+
+# The address at which the bootinfo struct will be placed. if not provided,
+# the bootloader will dynamically search for a location.
+boot-info-address = "0xFFFFFFFF80000000"
 ```
 
 Note that the addresses **must** be given as strings (in either hex or decimal format), as [TOML](https://github.com/toml-lang/toml) does not support unsigned 64-bit integers.

--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,7 @@ struct BootloaderConfig {
     physical_memory_offset: Option<u64>,
     kernel_stack_address: Option<u64>,
     kernel_stack_size: Option<u64>,
+    boot_info_address: Option<u64>,
 }
 
 #[cfg(feature = "binary")]
@@ -39,7 +40,8 @@ fn parse_to_config(cfg: &mut BootloaderConfig, table: &toml::value::Table) {
     for (key, value) in table {
         match (key.as_str(), value.clone()) {
             ("kernel-stack-address", Value::Integer(i))
-            | ("physical-memory-offset", Value::Integer(i)) => {
+            | ("physical-memory-offset", Value::Integer(i))
+            | ("boot-info-address", Value::Integer(i)) => {
                 panic!(
                     "`{0}` in the kernel manifest must be given as a string, \
                      as toml does not support unsigned 64-bit integers (try `{0} = \"{1}\"`)",
@@ -49,6 +51,9 @@ fn parse_to_config(cfg: &mut BootloaderConfig, table: &toml::value::Table) {
             }
             ("kernel-stack-address", Value::String(s)) => {
                 cfg.kernel_stack_address = Some(parse_aligned_addr(key.as_str(), &s));
+            }
+            ("boot-info-address", Value::String(s)) => {
+                cfg.boot_info_address = Some(parse_aligned_addr(key.as_str(), &s));
             }
             #[cfg(not(feature = "map_physical_memory"))]
             ("physical-memory-offset", Value::String(_)) => {
@@ -269,10 +274,12 @@ fn main() {
         format!(
             "const PHYSICAL_MEMORY_OFFSET: Option<u64> = {:?};
             const KERNEL_STACK_ADDRESS: Option<u64> = {:?};
-            const KERNEL_STACK_SIZE: u64 = {};",
+            const KERNEL_STACK_SIZE: u64 = {};
+            const BOOT_INFO_ADDRESS: Option<u64> = {:?};",
             bootloader_config.physical_memory_offset,
             bootloader_config.kernel_stack_address,
             bootloader_config.kernel_stack_size.unwrap_or(512), // size is in number of pages
+            bootloader_config.boot_info_address,
         )
         .as_bytes(),
     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -240,12 +240,15 @@ fn bootloader_main(
 
     // Map a page for the boot info structure
     let boot_info_page = {
-        let page: Page = Page::from_page_table_indices(
-            level4_entries.get_free_entry(),
-            PageTableIndex::new(0),
-            PageTableIndex::new(0),
-            PageTableIndex::new(0),
-        );
+        let page: Page = match BOOT_INFO_ADDRESS {
+            Some(addr) => Page::containing_address(VirtAddr::new(addr))
+            None => Page::from_page_table_indices(
+                level4_entries.get_free_entry(),
+                PageTableIndex::new(0),
+                PageTableIndex::new(0),
+                PageTableIndex::new(0),
+            ),
+        };
         let frame = frame_allocator
             .allocate_frame(MemoryRegionType::BootInfo)
             .expect("frame allocation failed");

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,7 +241,7 @@ fn bootloader_main(
     // Map a page for the boot info structure
     let boot_info_page = {
         let page: Page = match BOOT_INFO_ADDRESS {
-            Some(addr) => Page::containing_address(VirtAddr::new(addr))
+            Some(addr) => Page::containing_address(VirtAddr::new(addr)),
             None => Page::from_page_table_indices(
                 level4_entries.get_free_entry(),
                 PageTableIndex::new(0),


### PR DESCRIPTION
Resolve issue #100. This implements a `boot-info-address`, which instead of dynamically relocating the boot info struct, will place it at the provided address. This functions the same as the `kernel-stack-address` and `physical-memory-offset`.