### PR TITLE
Identity-map complete vga region (0xa0000 to 0xc0000)

### DIFF
--- a/src/video_mode/vga_320x200.s
+++ b/src/video_mode/vga_320x200.s
@@ -19,7 +19,7 @@ vga_map_frame_buffer_loop:
     mov [_p1 + ecx * 8], eax
 
     add eax, 4096
-    cmp eax, 0xbffff
+    cmp eax, 0xc0000
     jl vga_map_frame_buffer_loop
 
     ret

--- a/src/video_mode/vga_320x200.s
+++ b/src/video_mode/vga_320x200.s
@@ -19,7 +19,7 @@ vga_map_frame_buffer_loop:
     mov [_p1 + ecx * 8], eax
 
     add eax, 4096
-    cmp eax, 0xa0000 + 320 * 200
+    cmp eax, 0xbffff
     jl vga_map_frame_buffer_loop
 
     ret

--- a/src/video_mode/vga_text_80x25.s
+++ b/src/video_mode/vga_text_80x25.s
@@ -11,11 +11,17 @@ config_video_mode:
 .code32
 
 vga_map_frame_buffer:
-    mov eax, 0xb8000
+    mov eax, 0xa0000
     or eax, (1 | 2)
-    mov ecx, 0xb8000
+vga_map_frame_buffer_loop:
+    mov ecx, eax
     shr ecx, 12
     mov [_p1 + ecx * 8], eax
+
+    add eax, 4096
+    cmp eax, 0xbffff
+    jl vga_map_frame_buffer_loop
+
     ret
 
 # print a string and a newline

--- a/src/video_mode/vga_text_80x25.s
+++ b/src/video_mode/vga_text_80x25.s
@@ -19,7 +19,7 @@ vga_map_frame_buffer_loop:
     mov [_p1 + ecx * 8], eax
 
     add eax, 4096
-    cmp eax, 0xbffff
+    cmp eax, 0xc0000
     jl vga_map_frame_buffer_loop
 
     ret


### PR DESCRIPTION
I took the existing method from vga_320x200 and extended it to map through 0xbffff. I also added it in vga_80x25 so that regions are mapped regardless of which feature someone uses. Let me know if anything looks off.

_Edit (phil-opp)_: This PR extends the identity-mapping that we do for the VGA buffer at address 0xb8000 (or 0xa0000 with the vga_320x200) feature to all addresses in the range 0xa0000 to 0xc0000. This simplifies the switch to different VGA modes on the kernel side. This is a **breaking change** because it breaks kernels that try to map these virtual addresses themselves.