### PR TITLE
SSE feature: remove inline assembly + don't set reserved bits

### DIFF
--- a/src/sse.rs
+++ b/src/sse.rs
@@ -1,23 +1,17 @@
 /// Enables Streaming SIMD Extensions (SSE) support for loaded kernels.
 pub fn enable_sse() {
-    use bit_field::BitField;
-    use x86_64::registers::control::Cr0;
-    let mut flags = Cr0::read_raw();
-    flags.set_bit(2, false);
-    flags.set_bit(1, true);
-    flags.set_bit(9, true);
-    flags.set_bit(10, true);
+    use x86_64::registers::control::{Cr0, Cr0Flags, Cr4, Cr4Flags};
+    let mut flags = Cr0::read();
+    flags.remove(Cr0Flags::EMULATE_COPROCESSOR);
+    flags.insert(Cr0Flags::MONITOR_COPROCESSOR);
     unsafe {
-        Cr0::write_raw(flags);
+        Cr0::write(flags);
     }
-    // For now, we must use inline ASM here
-    let mut cr4: u64;
+
+    let mut flags = Cr4::read();
+    flags.insert(Cr4Flags::OSFXSR);
+    flags.insert(Cr4Flags::OSXMMEXCPT_ENABLE);
     unsafe {
-        asm!("mov %cr4, $0" : "=r" (cr4));
-    }
-    cr4.set_bit(9, true);
-    cr4.set_bit(10, true);
-    unsafe {
-        asm!("mov $0, %cr4" :: "r" (cr4) : "memory");
+        Cr4::write(flags);
     }
 }


### PR DESCRIPTION
- get rid of inline assembly
- for some reason the previous version also set bits 9 & 10 in Cr0. according to the developer manual bits 5-16 are reserved