### PR TITLE
Remove unused feature gates

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,6 @@
 #![feature(lang_items)]
 #![feature(global_asm)]
-#![feature(step_trait)]
 #![feature(llvm_asm)]
-#![feature(nll)]
-#![feature(const_fn)]
 #![no_std]
 #![no_main]
 


### PR DESCRIPTION
This crate is able to compile without any of these enabled.