### PR TITLE
rename _improper_ctypes_check functions

### DIFF
--- a/src/bootinfo/memory_map.rs
+++ b/src/bootinfo/memory_map.rs
@@ -232,5 +232,5 @@ impl From<E820MemoryRegion> for MemoryRegion {
 }
 
 extern "C" {
-    fn _improper_ctypes_check(_boot_info: MemoryMap);
+    fn _improper_ctypes_check_memory_map(_memory_map: MemoryMap);
 }

--- a/src/bootinfo/mod.rs
+++ b/src/bootinfo/mod.rs
@@ -116,5 +116,5 @@ pub struct TlsTemplate {
 }
 
 extern "C" {
-    fn _improper_ctypes_check(_boot_info: BootInfo);
+    fn _improper_ctypes_check_bootinfo(_boot_info: BootInfo);
 }


### PR DESCRIPTION
rustc seems to have added a warning for dupplicate extern functions with different signatures:
```
warning: `_improper_ctypes_check` redeclared with a different signature
   --> src/bootinfo/mod.rs:119:5
    |
119 |     fn _improper_ctypes_check(_boot_info: BootInfo);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this signature doesn't match the previous declaration
    | 
   ::: src/bootinfo/memory_map.rs:235:5
    |
235 |     fn _improper_ctypes_check(_boot_info: MemoryMap);
    |     ------------------------------------------------- `_improper_ctypes_check` previously declared here
    |
    = note: `#[warn(clashing_extern_decl)]` on by default
    = note: expected `unsafe extern "C" fn(bootinfo::memory_map::MemoryMap)`
               found `unsafe extern "C" fn(bootinfo::BootInfo)`
```

this pr simply renames the functions to get rid of the warning