### PR TITLE
Change 1st stage int 13h addressing

### DIFF
--- a/src/stage_1.s
+++ b/src/stage_1.s
@@ -80,8 +80,17 @@ check_int13h_extensions:
 load_rest_of_bootloader_from_disk:
     lea eax, _rest_of_bootloader_start_addr
 
-    # start of memory buffer
+    # dap buffer segment
+    mov ebx, eax
+    shr ebx, 4 # divide by 16
+    mov [dap_buffer_seg], bx
+
+    # buffer offset
+    shl ebx, 4 # multiply by 16
+    sub eax, ebx
     mov [dap_buffer_addr], ax
+
+    lea eax, _rest_of_bootloader_start_addr
 
     # number of disk blocks to load
     lea ebx, _rest_of_bootloader_end_addr
@@ -99,6 +108,9 @@ load_rest_of_bootloader_from_disk:
     mov ah, 0x42
     int 0x13
     jc rest_of_bootloader_load_failed
+    
+    # reset segment to 0
+    mov word ptr [dap_buffer_seg], 0
 
 jump_to_second_stage:
     lea eax, [stage_2]


### PR DESCRIPTION
Changed the addressing of the bootloader loading from disk on stage 1, so the buffer doesn't cross the memory segment boundary, as is required by int 13h/ah=42h (see [Wikipedia](https://en.wikipedia.org/wiki/INT_13H#INT_13h_AH=42h:_Extended_Read_Sectors_From_Drive)).

With this change the bootloader no longer gets stuck on stage 1 on VirtualBox. Also tested on QEMU and Bochs, but not on real hardware.

Feel free to rewrite in a better way as I have no previous experience with asm.