### PR TITLE
Make bootloader buildable with `-Zbuild-std`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,7 @@ dependencies = [
  "fixedvec 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "font8x8 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "llvm-tools 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rlibc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "usize_conversions 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "x86_64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -42,6 +43,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "llvm-tools"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rlibc"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -91,6 +97,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fixedvec 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b395ef2adf62bdeefcd1b59ad0dd2225c6c333ec79656ea79ac5285c46d051ea"
 "checksum font8x8 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "44226c40489fb1d602344a1d8f1b544570c3435e396dda1eda7b5ef010d8f1be"
 "checksum llvm-tools 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "955be5d0ca0465caf127165acb47964f911e2bc26073e865deb8be7189302faf"
+"checksum rlibc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"
 "checksum serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5626ac617da2f2d9c48af5515a21d5a480dbd151e01bb1c355e26a3e68113"
 "checksum toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b8c96d7873fa7ef8bdeb3a9cda3ac48389b4154f32b9803b4bc26220b677b039"
 "checksum usize_conversions 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f70329e2cbe45d6c97a5112daad40c34cd9a4e18edb5a2a18fefeb584d8d25e5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ x86_64 = { version = "0.11.0", optional = true }
 usize_conversions = { version = "0.2.0", optional = true }
 fixedvec = { version = "0.2.4", optional = true }
 bit_field = { version = "0.10.0", optional = true }
+rlibc = "1.0.0"
 
 [dependencies.font8x8]
 version = "0.2.4"
@@ -47,6 +48,7 @@ debug = true
 
 [package.metadata.bootloader]
 target = "x86_64-bootloader.json"
+build-std = "core"
 
 [package.metadata.docs.rs]
 features = [ "recursive_page_table", "map_physical_memory" ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@
 #[cfg(not(target_os = "none"))]
 compile_error!("The bootloader crate must be compiled for the `x86_64-bootloader.json` target");
 
+extern crate rlibc;
+
 use bootloader::bootinfo::{BootInfo, FrameRange};
 use core::convert::TryInto;
 use core::panic::PanicInfo;


### PR DESCRIPTION
This switches the bootloader build from `cargo-xbuild` to `cargo build -Zbuild-std=core`. It uses the new `package.metadata.bootloader.build-std` key of version 0.8.1 of `bootimage` for that.

This change is non-breaking since the bootloader continues to be buildable with `cargo-xbuild`.