### PR TITLE
Enable rlibc dependency only with `binary` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ x86_64 = { version = "0.11.0", optional = true }
 usize_conversions = { version = "0.2.0", optional = true }
 fixedvec = { version = "0.2.4", optional = true }
 bit_field = { version = "0.10.0", optional = true }
-rlibc = "1.0.0"
+rlibc = { version = "1.0.0", optional = true }
 
 [dependencies.font8x8]
 version = "0.2.4"
@@ -32,7 +32,7 @@ toml = { version = "0.5.1", optional = true }
 
 [features]
 default = []
-binary = ["xmas-elf", "x86_64", "usize_conversions", "fixedvec", "llvm-tools", "toml"]
+binary = ["xmas-elf", "x86_64", "usize_conversions", "fixedvec", "llvm-tools", "toml", "rlibc"]
 vga_320x200 = ["font8x8"]
 recursive_page_table = []
 map_physical_memory = []


### PR DESCRIPTION
The dependency is not needed when compiling the bootloader crate as a library.