### PR TITLE
Update Cargo.lock to prevent nightly breakage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,9 @@ checksum = "f70329e2cbe45d6c97a5112daad40c34cd9a4e18edb5a2a18fefeb584d8d25e5"
 
 [[package]]
 name = "x86_64"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238a5798f77641af3c4f242bf985807f312a480cd4e35ed7255fad4b2ccb9d4f"
+checksum = "d5b4b42dbabe13b69023e1a1407d395f1a1a33df76e9a9efdbe303acc907e292"
 dependencies = [
  "bit_field 0.9.0",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ required-features = ["binary"]
 
 [dependencies]
 xmas-elf = { version = "0.6.2", optional = true }
-x86_64 = { version = "0.12.1", optional = true }
+x86_64 = { version = "0.12.2", optional = true }
 usize_conversions = { version = "0.2.0", optional = true }
 fixedvec = { version = "0.2.4", optional = true }
 bit_field = { version = "0.10.0", optional = true }

--- a/example-kernel/Cargo.lock
+++ b/example-kernel/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "x86_64"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238a5798f77641af3c4f242bf985807f312a480cd4e35ed7255fad4b2ccb9d4f"
+checksum = "d5b4b42dbabe13b69023e1a1407d395f1a1a33df76e9a9efdbe303acc907e292"
 dependencies = [
  "bit_field",
  "bitflags",

--- a/example-kernel/Cargo.toml
+++ b/example-kernel/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 edition = "2018"
 
 [dependencies]
-x86_64 = "0.12.1"
+x86_64 = "0.12.2"

--- a/test-kernel/Cargo.lock
+++ b/test-kernel/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "x86_64"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238a5798f77641af3c4f242bf985807f312a480cd4e35ed7255fad4b2ccb9d4f"
+checksum = "d5b4b42dbabe13b69023e1a1407d395f1a1a33df76e9a9efdbe303acc907e292"
 dependencies = [
  "bit_field",
  "bitflags",

--- a/test-kernel/Cargo.toml
+++ b/test-kernel/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 edition = "2018"
 
 [dependencies]
-x86_64 = "0.12.1"
+x86_64 = "0.12.2"


### PR DESCRIPTION
See https://github.com/rust-osdev/x86_64/pull/186#issuecomment-700491664

Now that x86_64 has a "good" build, we just need a new lockfile to make things build.

Signed-off-by: Joe Richey <joerichey@google.com>