### PR TITLE
Fix "panic message is not a string literal"

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -125,7 +125,8 @@ fn main() {
     // check that the kernel file exists
     assert!(
         kernel.exists(),
-        format!("KERNEL does not exist: {}", kernel.display())
+        "KERNEL does not exist: {}",
+        kernel.display()
     );
 
     // get access to llvm tools shipped in the llvm-tools-preview rustup component


### PR DESCRIPTION
Updates build.rs to use the second form of the assert! macro, which can take a format string and arguments, without needing to use format!.

This should resolve #137.