### PR TITLE
Fix linker errors on latest nightlies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
         HOMEBREW_NO_INSTALL_CLEANUP: 1
     - name: Install QEMU (Windows)
       run: |
-        choco install qemu --no-progress
+        choco install qemu --version=2021.02.03 -y --no-progress
         echo "C:\Program Files\qemu" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       if: runner.os == 'Windows'
       shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
         HOMEBREW_NO_INSTALL_CLEANUP: 1
     - name: Install QEMU (Windows)
       run: |
-        choco install qemu --version=2021.02.03 -y --no-progress
+        choco install qemu --version=2020.11.20 -y --no-progress
         echo "C:\Program Files\qemu" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       if: runner.os == 'Windows'
       shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,10 +64,14 @@ jobs:
         HOMEBREW_NO_AUTO_UPDATE: 1
         HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: 1
         HOMEBREW_NO_INSTALL_CLEANUP: 1
-    - name: Install QEMU (Windows)
+    - name: Install Scoop (Windows)
       run: |
-        choco install qemu --version=2020.11.20 -y --no-progress
-        echo "C:\Program Files\qemu" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+        echo "$HOME\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      if: runner.os == 'Windows'
+      shell: pwsh
+    - name: Install QEMU (Windows)
+      run: scoop install qemu
       if: runner.os == 'Windows'
       shell: pwsh
     - name: "Print QEMU Version"
@@ -78,7 +82,14 @@ jobs:
         qemu-system-x86_64 -drive format=raw,file=target/x86_64-bootloader/release/bootloader.bin -device isa-debug-exit,iobase=0xf4,iosize=0x04 -display none
         if [ $? -eq 123 ]; then (exit 0); else (exit 1); fi
       shell: 'bash {0}'
+      if: runner.os != 'Windows'
 
+    - name: 'Run Test Kernel with Bootloader (Windows)'
+      run: |
+        qemu-system-x86_64 -drive format=raw,file=target/x86_64-bootloader/release/bootloader.bin -device isa-debug-exit,iobase=0xf4,iosize=0x04 -display none -L "C:\Program Files\qemu"
+        if [ $? -eq 123 ]; then (exit 0); else (exit 1); fi
+      shell: 'bash {0}'
+      if: runner.os == 'Windows'
 
   build_example_kernel:
     name: "Build Example Kernel"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
       if: runner.os == 'Windows'
       shell: pwsh
     - name: Install QEMU (Windows)
-      run: scoop install qemu@5.1.0
+      run: scoop install qemu@5.2.0-rc2
       if: runner.os == 'Windows'
       shell: pwsh
     - name: "Print QEMU Version"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
       if: runner.os == 'Windows'
       shell: pwsh
     - name: Install QEMU (Windows)
-      run: scoop install qemu@5.2.0-rc2
+      run: scoop install qemu@5.1.0
       if: runner.os == 'Windows'
       shell: pwsh
     - name: "Print QEMU Version"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,9 @@ jobs:
         HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: 1
         HOMEBREW_NO_INSTALL_CLEANUP: 1
     - name: Install QEMU (Windows)
-      run: choco install qemu
+      run: |
+        choco install qemu
+        echo "C:\Program Files\qemu" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       if: runner.os == 'Windows'
       shell: pwsh
     - name: "Print QEMU Version"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
     name: "Test"
 
     strategy:
+      fail-fast: false
       matrix:
         platform: [
           ubuntu-latest,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
         HOMEBREW_NO_INSTALL_CLEANUP: 1
     - name: Install QEMU (Windows)
       run: |
-        choco install qemu --limit-output
+        choco install qemu --no-progress
         echo "C:\Program Files\qemu" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       if: runner.os == 'Windows'
       shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
       if: runner.os == 'Windows'
       shell: pwsh
     - name: Install QEMU (Windows)
-      run: scoop install qemu
+      run: scoop install qemu@5.2.0-rc2
       if: runner.os == 'Windows'
       shell: pwsh
     - name: "Print QEMU Version"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,14 +83,6 @@ jobs:
         qemu-system-x86_64 -drive format=raw,file=target/x86_64-bootloader/release/bootloader.bin -device isa-debug-exit,iobase=0xf4,iosize=0x04 -display none
         if [ $? -eq 123 ]; then (exit 0); else (exit 1); fi
       shell: 'bash {0}'
-      if: runner.os != 'Windows'
-
-    - name: 'Run Test Kernel with Bootloader (Windows)'
-      run: |
-        qemu-system-x86_64 -drive format=raw,file=target/x86_64-bootloader/release/bootloader.bin -device isa-debug-exit,iobase=0xf4,iosize=0x04 -display none -L "C:\Program Files\qemu"
-        if [ $? -eq 123 ]; then (exit 0); else (exit 1); fi
-      shell: 'bash {0}'
-      if: runner.os == 'Windows'
 
   build_example_kernel:
     name: "Build Example Kernel"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
         HOMEBREW_NO_INSTALL_CLEANUP: 1
     - name: Install QEMU (Windows)
       run: |
-        choco install qemu
+        choco install qemu --limit-output
         echo "C:\Program Files\qemu" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       if: runner.os == 'Windows'
       shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,14 +64,8 @@ jobs:
         HOMEBREW_NO_AUTO_UPDATE: 1
         HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: 1
         HOMEBREW_NO_INSTALL_CLEANUP: 1
-    - name: Install Scoop (Windows)
-      run: |
-        Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
-        echo "$HOME\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      if: runner.os == 'Windows'
-      shell: pwsh
     - name: Install QEMU (Windows)
-      run: scoop install qemu@5.2.0-rc2
+      run: choco install qemu
       if: runner.os == 'Windows'
       shell: pwsh
     - name: "Print QEMU Version"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bootloader"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "bit_field 0.10.1",
  "fixedvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bootloader"
-version = "0.9.14"
+version = "0.9.15"
 authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 license = "MIT/Apache-2.0"
 description = "An experimental pure-Rust x86 bootloader."

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 0.9.15 – 2021-03-07
+
+- Fix linker errors on latest nightlies ([#139](https://github.com/rust-osdev/bootloader/pull/139))
+
 # 0.9.14 – 2021-02-24
 
 - Fix "panic message is not a string literal" warning ([#138](https://github.com/rust-osdev/bootloader/pull/138))

--- a/src/stage_1.s
+++ b/src/stage_1.s
@@ -78,7 +78,7 @@ check_int13h_extensions:
     jc no_int13h_extensions
 
 load_rest_of_bootloader_from_disk:
-    lea eax, _rest_of_bootloader_start_addr
+    mov eax, offset _rest_of_bootloader_start_addr
 
     # dap buffer segment
     mov ebx, eax
@@ -90,7 +90,7 @@ load_rest_of_bootloader_from_disk:
     sub eax, ebx
     mov [dap_buffer_addr], ax
 
-    lea eax, _rest_of_bootloader_start_addr
+    mov eax, offset _rest_of_bootloader_start_addr
 
     # number of disk blocks to load
     lea ebx, _rest_of_bootloader_end_addr

--- a/src/stage_1.s
+++ b/src/stage_1.s
@@ -93,7 +93,7 @@ load_rest_of_bootloader_from_disk:
     mov eax, offset _rest_of_bootloader_start_addr
 
     # number of disk blocks to load
-    lea ebx, _rest_of_bootloader_end_addr
+    mov ebx, offset _rest_of_bootloader_end_addr
     sub ebx, eax # end - start
     shr ebx, 9 # divide by 512 (block size)
     mov [dap_blocks], bx

--- a/src/stage_2.s
+++ b/src/stage_2.s
@@ -40,8 +40,8 @@ load_kernel_from_disk:
     mov word ptr [dap_blocks], 1
 
     # number of start block
-    lea eax, _kernel_start_addr
-    lea ebx, _start
+    mov eax, offset _kernel_start_addr
+    mov ebx, offset _start
     sub eax, ebx
     shr eax, 9 # divide by 512 (block size)
     mov [dap_start_lba], eax


### PR DESCRIPTION
Don't use the `lea` instructions get addresses of non-addressable memory locations. Instead, use `mov <reg>, offset <label>` instructions, which are the equivalent to `mov <reg>, label` instructions in `nasm`.

I'm not sure why the `lea` worked before, but maybe LLVM used to optimize the `lea`s to `mov` instructions. Either way, the LLVM version used by the latest Rust nightly doesn't like the `lea` instructions anymore.

This PR includes a lot of commits where I tried to fix the Windows CI, which currently fails because of a [bug in QEMU](https://bugs.launchpad.net/qemu/+bug/1915794). Unfortunately, I wasn't able to get it working, so I just hope for a new QEMU release now. For the meantime, I disabled the `fail-fast` property so that we at least don't cancel the macOS build when the Windows job fails. (I kept the debug commits in this PR in case so that I don't need to rember which approaches I tried the next time I debug this.)

Fixes https://github.com/rust-osdev/bootimage/issues/73 and fixes https://github.com/phil-opp/blog_os/issues/937