### PR TITLE
Replace all remaining `lea`s with `mov` + `offset`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+Replace all remaining `lea`s with `mov` + `offset` ([#140](https://github.com/rust-osdev/bootloader/pull/140))
+
 # 0.9.15 – 2021-03-07
 
 - Fix linker errors on latest nightlies ([#139](https://github.com/rust-osdev/bootloader/pull/139))

--- a/src/stage_1.s
+++ b/src/stage_1.s
@@ -22,7 +22,7 @@ _start:
     # initialize stack
     mov sp, 0x7c00
 
-    lea si, boot_start_str
+    mov si, offset boot_start_str
     call real_mode_println
 
 enable_a20:
@@ -99,12 +99,12 @@ load_rest_of_bootloader_from_disk:
     mov [dap_blocks], bx
 
     # number of start block
-    lea ebx, _start
+    mov ebx, offset _start
     sub eax, ebx
     shr eax, 9 # divide by 512 (block size)
     mov [dap_start_lba], eax
 
-    lea si, dap
+    mov si, offset dap
     mov ah, 0x42
     int 0x13
     jc rest_of_bootloader_load_failed
@@ -113,7 +113,7 @@ load_rest_of_bootloader_from_disk:
     mov word ptr [dap_buffer_seg], 0
 
 jump_to_second_stage:
-    lea eax, [stage_2]
+    mov eax, offset stage_2
     jmp eax
 
 spin:
@@ -190,11 +190,11 @@ real_mode_error:
     jmp spin
 
 no_int13h_extensions:
-    lea si, no_int13h_extensions_str
+    mov si, offset no_int13h_extensions_str
     jmp real_mode_error
 
 rest_of_bootloader_load_failed:
-    lea si, rest_of_bootloader_load_failed_str
+    mov si, offset rest_of_bootloader_load_failed_str
     jmp real_mode_error
 
 boot_start_str: .asciz "Booting (first stage)..."

--- a/src/stage_2.s
+++ b/src/stage_2.s
@@ -10,13 +10,13 @@ second_stage_start_str: .asciz "Booting (second stage)..."
 kernel_load_failed_str: .asciz "Failed to load kernel from disk"
 
 kernel_load_failed:
-    lea si, [kernel_load_failed_str]
+    mov si, offset kernel_load_failed_str
     call real_mode_println
 kernel_load_failed_spin:
     jmp kernel_load_failed_spin
 
 stage_2:
-    lea si, [second_stage_start_str]
+    mov si, offset second_stage_start_str
     call real_mode_println
 
 set_target_operating_mode:
@@ -33,7 +33,7 @@ set_target_operating_mode:
 
 load_kernel_from_disk:
     # start of memory buffer
-    lea eax, _kernel_buffer
+    mov eax, offset _kernel_buffer
     mov [dap_buffer_addr], ax
 
     # number of disk blocks to load
@@ -50,13 +50,13 @@ load_kernel_from_disk:
     mov edi, 0x400000
 
     # block count
-    lea ecx, _kernel_size
+    mov ecx, offset _kernel_size
     add ecx, 511 # align up
     shr ecx, 9
 
 load_next_kernel_block_from_disk:
     # load block from disk
-    lea si, dap
+    mov si, offset dap
     mov ah, 0x42
     int 0x13
     jc kernel_load_failed
@@ -97,7 +97,7 @@ enter_protected_mode_again:
     mov cr0, eax
 
     push 0x8
-    lea eax, [stage_3]
+    mov eax, offset stage_3
     push eax
     retf
 

--- a/src/stage_3.s
+++ b/src/stage_3.s
@@ -13,7 +13,7 @@ stage_3:
     mov es, bx # set extra segment
     mov ss, bx # set stack segment
 
-    lea si, boot_third_stage_str
+    mov si, offset boot_third_stage_str
     call vga_println
 
 check_cpu:
@@ -28,28 +28,28 @@ check_cpu:
 
 set_up_page_tables:
     # zero out buffer for page tables
-    lea edi, [__page_table_start]
-    lea ecx, [__page_table_end]
+    mov edi, offset __page_table_start
+    mov ecx, offset __page_table_end
     sub ecx, edi
     shr ecx, 2 # one stosd zeros 4 bytes -> divide by 4
     xor eax, eax
     rep stosd
 
     # p4
-    lea eax, [_p3]
+    mov eax, offset _p3
     or eax, (1 | 2)
     mov [_p4], eax
     # p3
-    lea eax, [_p2]
+    mov eax, offset _p2
     or eax, (1 | 2)
     mov [_p3], eax
     # p2
-    lea eax, [_p1]
+    mov eax, offset _p1
     or eax, (1 | 2)
     mov [_p2], eax
     mov eax, (0x400000 | 1 | 2 | (1 << 7))
     mov ecx, 2
-    lea edx, _kernel_size
+    mov edx, offset _kernel_size
     add edx, 0x400000 # start address
     add edx, 0x200000 - 1 # align up
     shr edx, 12 + 9 # end huge page number
@@ -62,12 +62,12 @@ set_up_page_tables:
     # p1
     # start mapping from __page_table_start, as we need to be able to access
     # the p4 table from rust. stop mapping at __bootloader_end
-    lea eax, __page_table_start
+    mov eax, offset __page_table_start
     and eax, 0xfffff000
     or eax, (1 | 2)
-    lea ecx, __page_table_start
+    mov ecx, offset __page_table_start
     shr ecx, 12 # start page number
-    lea edx, __bootloader_end
+    mov edx, offset __bootloader_end
     add edx, 4096 - 1 # align up
     shr edx, 12 # end page number
     map_p1_table:
@@ -86,7 +86,7 @@ enable_paging:
     mfence
 
     # load P4 to cr3 register (cpu uses this to access the P4 table)
-    lea eax, [_p4]
+    mov eax, offset _p4
     mov cr3, eax
 
     # enable PAE-flag in cr4 (Physical Address Extension)
@@ -110,7 +110,7 @@ load_64bit_gdt:
 
 jump_to_long_mode:
     push 0x8
-    lea eax, [stage_4]
+    mov eax, offset stage_4
     push eax
     retf # Load CS with 64 bit segment and flush the instruction cache
 
@@ -150,7 +150,7 @@ check_cpuid:
     je no_cpuid
     ret
 no_cpuid:
-    lea esi, no_cpuid_str
+    mov esi, offset no_cpuid_str
     call vga_println
 no_cpuid_spin:
     hlt
@@ -170,7 +170,7 @@ check_long_mode:
     jz no_long_mode        # If it's not set, there is no long mode
     ret
 no_long_mode:
-    lea esi, no_long_mode_str
+    mov esi, offset no_long_mode_str
     call vga_println
 no_long_mode_spin:
     hlt


### PR DESCRIPTION
Follow-up to #139 since there were still [some relocation errors](https://github.com/phil-opp/blog_os/issues/937#issuecomment-792306992) for real-world kernels.