### PR TITLE
llvm_asm! -> asm!

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Use new `asm!` syntax instead of deprecated `llvm_asm!` ([#148](https://github.com/rust-osdev/bootloader/154))
+
 # 0.10.1 – 2021-04-07
 
 - Fix docs.rs build: Don't enable any features

--- a/src/bin/bios.rs
+++ b/src/bin/bios.rs
@@ -1,6 +1,5 @@
 #![feature(lang_items)]
 #![feature(global_asm)]
-#![feature(llvm_asm)]
 #![feature(asm)]
 #![no_std]
 #![no_main]
@@ -51,8 +50,10 @@ extern "C" {
 #[no_mangle]
 pub unsafe extern "C" fn stage_4() -> ! {
     // Set stack segment
-    llvm_asm!("mov bx, 0x0
-          mov ss, bx" ::: "bx" : "intel");
+    asm!(
+        "mov bx, 0x0; mov ss, bx",
+        out("bx") _,
+    );
 
     let kernel_start = 0x400000;
     let kernel_size = &_kernel_size as *const _ as u64;


### PR DESCRIPTION
Tiny change to stop using `llvm_asm!`, as everywhere else is using `asm!` and the feature is basically deprecated.