### PR TITLE
Change register used in setting SS in stage_4

### DIFF
--- a/src/bin/bios.rs
+++ b/src/bin/bios.rs
@@ -51,8 +51,8 @@ extern "C" {
 pub unsafe extern "C" fn stage_4() -> ! {
     // Set stack segment
     asm!(
-        "mov bx, 0x0; mov ss, bx",
-        out("bx") _,
+        "mov ax, 0x0; mov ss, ax",
+        out("ax") _,
     );
 
     let kernel_start = 0x400000;


### PR DESCRIPTION
The register `bx` is apparently reserved by LLVM, and building with the latest nightly (1.54-nightly) fails because of it:

```
error: invalid register `bx`: rbx is used internally by LLVM and cannot be used as an operand for inline asm
  --> src\bin\bios.rs:55:9
   |
55 |         out("bx") _,
   |  
```

This pull request changes the register used to `ax`.
I don't think this'll be able to break anything. `cargo test` passes, and building and running my own kernel works.