### PR TITLE
Fix nightly regression by manually passing `--gc-sections`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix nightly regression by manually passing --gc-sections ([#168](https://github.com/rust-osdev/bootloader/pull/168))
+
 # 0.9.17 – 2021-04-30
 
 - Reduce the number of used unstable features of x86_64 crate (backport [#155](https://github.com/rust-osdev/bootloader/pull/140))

--- a/x86_64-bootloader.json
+++ b/x86_64-bootloader.json
@@ -5,9 +5,9 @@
     "linker": "rust-lld",
     "pre-link-args": {
         "ld.lld": [
-	        "--script=linker.ld",
+            "--script=linker.ld",
             "--gc-sections"
-	    ]
+        ]
     },
     "target-endian": "little",
     "target-pointer-width": "64",

--- a/x86_64-bootloader.json
+++ b/x86_64-bootloader.json
@@ -18,5 +18,5 @@
     "disable-redzone": true,
     "panic": "abort",
     "executables": true,
-	"relocation_model": "static"
+    "relocation_model": "static"
 }

--- a/x86_64-bootloader.json
+++ b/x86_64-bootloader.json
@@ -5,8 +5,9 @@
     "linker": "rust-lld",
     "pre-link-args": {
         "ld.lld": [
-	    "--script=linker.ld"
-	]
+	        "--script=linker.ld",
+            "--gc-sections"
+	    ]
     },
     "target-endian": "little",
     "target-pointer-width": "64",


### PR DESCRIPTION
Rust used to pass `--gc-section` automatically. In https://github.com/rust-lang/rust/pull/85274, this behavior was changed to only pass that flag for targets that use a GNU linker. So we have to add it manually, otherwise the bootloader grows too large to be loaded by our assembly stage.

Fixes #167

This is a hotfix for the `v0.9.17` release and does not apply to the `main` branch (which needs some additional fixes).