### PR TITLE
Make bootloader v0.10 compatible with latest Rust nightlies by updating `uefi-rs` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64794316d667394f16a4cd72ab728f0bff4b9f2d2da3a9a1aff333af80c2b096"
+checksum = "4630a92e80ac72f2b3dedb865dac3cf9e0215ce7e222301f0a37d8e6e3c5dbf4"
 dependencies = [
  "bitflags",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,9 +184,9 @@ checksum = "e63201c624b8c8883921b1a1accc8916c4fa9dbfb15d122b26e4dde945b86bbf"
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
  "libc",
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3c91c24eae6777794bb1997ad98bbb87daf92890acab859f7eaa4320333176"
+checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
 dependencies = [
  "scopeguard",
 ]
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]
@@ -321,18 +321,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -341,18 +341,18 @@ dependencies = [
 
 [[package]]
 name = "spinning_top"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd0ab6b8c375d2d963503b90d3770010d95bc3b5f98036f948dee24bf4e8879"
+checksum = "75adad84ee84b521fb2cca2d4fd0f1dab1d8d026bda3c5bea4ca63b5f9f9293c"
 dependencies = [
  "lock_api",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad184cc9470f9117b2ac6817bfe297307418819ba40552f9b3846f05c33d5373"
+checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -427,12 +427,12 @@ dependencies = [
 
 [[package]]
 name = "uart_16550"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e09a33949dbbdeaa40f59d7ede389bba927c90b7ad411b91bb9617be3694267b"
+checksum = "503a6c0e6d82daa87985e662d120c0176b09587c92a68db22781b28ae95405dd"
 dependencies = [
  "bitflags",
- "x86_64 0.14.0",
+ "x86_64 0.14.2",
 ]
 
 [[package]]
@@ -446,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e008be83f40df3c5ebf67bacdbc85ee41c2c1185d27ceb4e91f7a6744a0afc1d"
+checksum = "64794316d667394f16a4cd72ab728f0bff4b9f2d2da3a9a1aff333af80c2b096"
 dependencies = [
  "bitflags",
  "log",
@@ -540,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "x86_64"
-version = "0.14.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c48c878623ca5318ce0d3fde56541e05c973e1683cfc19d5384db516999569dc"
+checksum = "13f09cffc08ee86bf5e4d147f107a43de0885c53ffad799b39f4ad203fb2a27d"
 dependencies = [
  "bit_field 0.9.0",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ x86_64 = { version = "0.13.2", optional = true, default-features = false, featur
 usize_conversions = { version = "0.2.0", optional = true }
 bit_field = { version = "0.10.0", optional = true }
 log = { version = "0.4.8", optional = true }
-uefi = { version = "0.9.0", optional = true }
+uefi = { version = "0.10.0", optional = true }
 argh = { version = "0.1.3", optional = true }
 displaydoc = { version = "0.1.7", optional = true }
 conquer-once = { version = "0.2.1", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ x86_64 = { version = "0.13.2", optional = true, default-features = false, featur
 usize_conversions = { version = "0.2.0", optional = true }
 bit_field = { version = "0.10.0", optional = true }
 log = { version = "0.4.8", optional = true }
-uefi = { version = "0.10.0", optional = true }
+uefi = { version = "0.11.0", optional = true }
 argh = { version = "0.1.3", optional = true }
 displaydoc = { version = "0.1.7", optional = true }
 conquer-once = { version = "0.2.1", optional = true, default-features = false }

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- Fix build on latest Rust nightlies by updating `uefi-rs` dependency ([#170](https://github.com/rust-osdev/bootloader/pull/170))
+  - Also: Fix warnings about `.intel_syntax` attribute in assembly code
+
 # 0.10.4 – 2021-05-14
 
 - Fix build on latest Rust nightly by updating to `uefi` v0.9.0 ([#162](https://github.com/rust-osdev/bootloader/pull/162))

--- a/src/asm/e820.s
+++ b/src/asm/e820.s
@@ -1,5 +1,4 @@
 .section .boot, "awx"
-.intel_syntax noprefix
 .code16
 
 # From http://wiki.osdev.org/Detecting_Memory_(x86)#Getting_an_E820_Memory_Map

--- a/src/asm/stage_1.s
+++ b/src/asm/stage_1.s
@@ -1,6 +1,5 @@
 .section .boot-first-stage, "awx"
 .global _start
-.intel_syntax noprefix
 .code16
 
 # This stage initializes the stack, enables the A20 line, loads the rest of

--- a/src/asm/stage_2.s
+++ b/src/asm/stage_2.s
@@ -1,5 +1,4 @@
 .section .boot, "awx"
-.intel_syntax noprefix
 .code16
 
 # This stage sets the target operating mode, loads the kernel from disk,

--- a/src/asm/stage_3.s
+++ b/src/asm/stage_3.s
@@ -1,5 +1,4 @@
 .section .boot, "awx"
-.intel_syntax noprefix
 .code32
 
 # This stage performs some checks on the CPU (cpuid, long mode), sets up an

--- a/src/asm/vesa.s
+++ b/src/asm/vesa.s
@@ -3,7 +3,6 @@
 # Copyright (c) 2017 Redox OS, licensed under MIT License
 
 .section .boot, "awx"
-.intel_syntax noprefix
 .code16
 
 vesa:

--- a/tests/test_kernels/higher_half/src/bin/verify_higher_half.rs
+++ b/tests/test_kernels/higher_half/src/bin/verify_higher_half.rs
@@ -17,6 +17,9 @@ fn kernel_main(_boot_info: &'static mut BootInfo) -> ! {
 
 /// This function is called on panic.
 #[panic_handler]
-fn panic(_info: &PanicInfo) -> ! {
+fn panic(info: &PanicInfo) -> ! {
+    use core::fmt::Write;
+
+    let _ = writeln!(test_kernel_higher_half::serial(), "PANIC: {}", info);
     exit_qemu(QemuExitCode::Failed);
 }

--- a/tests/test_kernels/higher_half/x86_64-higher_half.json
+++ b/tests/test_kernels/higher_half/x86_64-higher_half.json
@@ -13,6 +13,6 @@
     "disable-redzone": true,
     "features": "-mmx,-sse,+soft-float",
     "pre-link-args": {
-      "ld.lld": ["--image-base", "0xFFFF800000000000"]
+      "ld.lld": ["--image-base", "0xFFFF800000000000", "--gc-sections"]
     }
   }

--- a/x86_64-bootloader.json
+++ b/x86_64-bootloader.json
@@ -5,8 +5,9 @@
     "linker": "rust-lld",
     "pre-link-args": {
         "ld.lld": [
-	    "--script=linker.ld"
-	]
+            "--script=linker.ld",
+            "--gc-sections"
+        ]
     },
     "target-endian": "little",
     "target-pointer-width": "64",
@@ -17,5 +18,5 @@
     "disable-redzone": true,
     "panic-strategy": "abort",
     "executables": true,
-	"relocation_model": "static"
+    "relocation_model": "static"
 }


### PR DESCRIPTION
Fixes #169 