### PR TITLE
Uefi: Look for an ACPI2 RSDP first

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Uefi: Look for an ACPI2 RSDP first ([#174](https://github.com/rust-osdev/bootloader/pull/174))
+
 # 0.10.5 – 2021-05-21
 
 - Fix build on latest Rust nightlies by updating `uefi-rs` dependency ([#170](https://github.com/rust-osdev/bootloader/pull/170))

--- a/src/bin/uefi.rs
+++ b/src/bin/uefi.rs
@@ -61,7 +61,7 @@ fn efi_main(image: Handle, st: SystemTable<Boot>) -> Status {
             let mut config_entries = system_table.config_table().iter();
             // look for an ACPI2 RSDP first
             let acpi2_rsdp = config_entries.find(|entry| matches!(entry.guid, cfg::ACPI2_GUID));
-            // if no ACPI2 RSDP is found, look for a ACPI RSDP
+            // if no ACPI2 RSDP is found, look for a ACPI1 RSDP
             let rsdp = acpi2_rsdp
                 .or_else(|| config_entries.find(|entry| matches!(entry.guid, cfg::ACPI_GUID)));
             rsdp.map(|entry| PhysAddr::new(entry.address as u64));

--- a/src/bin/uefi.rs
+++ b/src/bin/uefi.rs
@@ -64,7 +64,7 @@ fn efi_main(image: Handle, st: SystemTable<Boot>) -> Status {
             // if no ACPI2 RSDP is found, look for a ACPI1 RSDP
             let rsdp = acpi2_rsdp
                 .or_else(|| config_entries.find(|entry| matches!(entry.guid, cfg::ACPI_GUID)));
-            rsdp.map(|entry| PhysAddr::new(entry.address as u64));
+            rsdp.map(|entry| PhysAddr::new(entry.address as u64))
         },
     };
 


### PR DESCRIPTION
Only look for an ACPI v1 RSDP if no v2 RSDP was found.

Fixes https://github.com/rust-osdev/bootloader/issues/172.