### PR TITLE
Don't check target architecture for builder crate to support cross-compiling

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 - Identity-map GDT into kernel address space to fix `iretq` ([#175](https://github.com/rust-osdev/bootloader/pull/175))
 - Uefi: Look for an ACPI2 RSDP first ([#174](https://github.com/rust-osdev/bootloader/pull/174))
+- Don't check target architecture for builder crate to support cross-compiling ([#176](https://github.com/rust-osdev/bootloader/pull/176))
 
 # 0.10.5 – 2021-05-21
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,13 +95,17 @@ pub mod binary;
 #[cfg(feature = "builder")]
 pub mod disk_image;
 
-#[cfg(target_arch = "x86")]
+#[cfg(all(target_arch = "x86", not(feature = "builder")))]
 compile_error!(
     "This crate currently does not support 32-bit protected mode. \
          See https://github.com/rust-osdev/bootloader/issues/70 for more information."
 );
 
-#[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
+#[cfg(all(
+    not(target_arch = "x86_64"),
+    not(target_arch = "x86"),
+    not(feature = "builder")
+))]
 compile_error!("This crate only supports the x86_64 architecture.");
 
 /// Defines the entry point function.


### PR DESCRIPTION
Fixes #173 