### PR TITLE
UEFI GOP mode configuration

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -75,4 +75,16 @@ pub struct Config {
     ///
     /// Only considered if `map_framebuffer` is `true`.
     pub framebuffer_address: Option<u64>,
+    /// Desired height of the framebuffer mode when running in UEFI mode.
+    ///
+    /// Defaults to using the default mode if neither `desired_framebuffer_height` or
+    /// `desired_framebuffer_width` is supplied, and using the last available mode that
+    /// fits them if 1 or more is set.
+    pub desired_framebuffer_height: Option<usize>,
+    /// Desired width of the framebuffer mode when running in UEFI mode.
+    ///
+    /// Defaults to using the default mode if neither `desired_framebuffer_height` or
+    /// `desired_framebuffer_width` is supplied, and using the last available mode that
+    /// fits them if 1 or more is set.
+    pub desired_framebuffer_width: Option<usize>,
 }


### PR DESCRIPTION
This pull request adds `desired_framebuffer_height` and `desired_framebuffer_width` to the bootloader configuration, and makes the UEFI bootloader select and set a GOP mode with those parameters if one is available.

Some things I'm not quite happy with yet, but am unsure how to fix:
- This does handle BIOS/VESA. I sadly don't have much knowledge of x86 assembly and don't think I'd be able to add this
- `Config` gets written twice now, so that ` bin/uefi.rs` has access to the config. Seems not ideal, but unsure how to improve this.

This is my first PR and I hope it is useful. Thank you for this great project! It has been a great help in learning about OS development.