### PR TITLE
pad uefi fat file length

### DIFF
--- a/src/bin/builder.rs
+++ b/src/bin/builder.rs
@@ -252,9 +252,9 @@ fn create_uefi_disk_image(executable_path: &Path, efi_file: &Path) -> anyhow::Re
             .truncate(true)
             .open(&fat_path)
             .context("Failed to create UEFI FAT file")?;
-        let efi_size_rounded = ((efi_size - 1) / MB + 1) * MB;
+        let efi_size_padded_and_rounded = ((efi_size + 1024 * 64 - 1) / MB + 1) * MB;
         fat_file
-            .set_len(efi_size_rounded)
+            .set_len(efi_size_padded_and_rounded)
             .context("failed to set UEFI FAT file length")?;
 
         // create new FAT partition


### PR DESCRIPTION
I got the following error during build:
```
Error: failed to create UEFI disk image

Caused by:
    No space left on device
thread 'main' panicked at 'build failed', simple_boot/src/main.rs:100:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Aborted (core dumped)
```

This error occured because the file size of the uefi binary was too close to the created uefi fat file size (in my case the uefi binary was `4184064` bytes and the fat file was `4194304` bytes big). I solved it by adding some padding to make sure that the difference between the binary's size and fat file's size isn't too small. I don't know much about fat so I just guessed the padding. If there's a proper way to calculate the required padding we should probably add that instead.