### PR TITLE
Fix compilation warnings on v0.9 branch

### DIFF
--- a/src/e820.s
+++ b/src/e820.s
@@ -1,5 +1,4 @@
 .section .boot, "awx"
-.intel_syntax noprefix
 .code16
 
 # From http://wiki.osdev.org/Detecting_Memory_(x86)#Getting_an_E820_Memory_Map

--- a/src/stage_1.s
+++ b/src/stage_1.s
@@ -1,6 +1,5 @@
 .section .boot-first-stage, "awx"
 .global _start
-.intel_syntax noprefix
 .code16
 
 # This stage initializes the stack, enables the A20 line, loads the rest of

--- a/src/stage_2.s
+++ b/src/stage_2.s
@@ -1,5 +1,4 @@
 .section .boot, "awx"
-.intel_syntax noprefix
 .code16
 
 # This stage sets the target operating mode, loads the kernel from disk,

--- a/src/stage_3.s
+++ b/src/stage_3.s
@@ -1,5 +1,4 @@
 .section .boot, "awx"
-.intel_syntax noprefix
 .code32
 
 # This stage performs some checks on the CPU (cpuid, long mode), sets up an

--- a/src/video_mode/vga_320x200.s
+++ b/src/video_mode/vga_320x200.s
@@ -1,5 +1,4 @@
 .section .boot, "awx"
-.intel_syntax noprefix
 .code16
 
 config_video_mode:

--- a/src/video_mode/vga_text_80x25.s
+++ b/src/video_mode/vga_text_80x25.s
@@ -1,5 +1,4 @@
 .section .boot, "awx"
-.intel_syntax noprefix
 .code16
 
 config_video_mode:

--- a/x86_64-bootloader.json
+++ b/x86_64-bootloader.json
@@ -17,6 +17,5 @@
     "features": "-mmx,-sse,+soft-float",
     "disable-redzone": true,
     "panic-strategy": "abort",
-    "executables": true,
-    "relocation_model": "static"
+    "executables": true
 }

--- a/x86_64-bootloader.json
+++ b/x86_64-bootloader.json
@@ -17,5 +17,6 @@
     "features": "-mmx,-sse,+soft-float",
     "disable-redzone": true,
     "panic-strategy": "abort",
-    "executables": true
+    "executables": true,
+    "relocation-model": "static"
 }

--- a/x86_64-bootloader.json
+++ b/x86_64-bootloader.json
@@ -16,7 +16,7 @@
     "os": "none",
     "features": "-mmx,-sse,+soft-float",
     "disable-redzone": true,
-    "panic": "abort",
+    "panic-strategy": "abort",
     "executables": true,
     "relocation_model": "static"
 }


### PR DESCRIPTION
Hello, I get some warnings on the 0.9.18 version when compiling MOROS (https://github.com/vinc/moros)
```
warning: avoid using `.intel_syntax`, Intel syntax is the default
```
And also
```
warning: target json file contains unused fields: panic, relocation_model
```

The fixes for `intel_syntax` and `panic` already exist for the main branch so I adapted them.

I also removed `relocation_model` from the JSON target file and tested it on my OS with Bosch, QEMU, and VirtualBox but not yet on real hardware so I'm unsure about that one.

Edit: I renamed the later to `relocation-model` to fix the warning thanks to @bjorn3 (see https://doc.rust-lang.org/rustc/codegen-options/index.html#relocation-model)