### PR TITLE
Fix `asm` imports on latest nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,12 +45,6 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bit_field"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed8765909f9009617974ab6b7d332625b320b33c326b1e9321382ef1999b5d56"
-
-[[package]]
-name = "bit_field"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
@@ -67,7 +61,7 @@ version = "0.10.9"
 dependencies = [
  "anyhow",
  "argh",
- "bit_field 0.10.1",
+ "bit_field",
  "conquer-once",
  "displaydoc",
  "fatfs",
@@ -85,7 +79,7 @@ dependencies = [
  "toml",
  "uefi",
  "usize_conversions",
- "x86_64 0.13.6",
+ "x86_64",
  "xmas-elf",
 ]
 
@@ -365,7 +359,7 @@ version = "0.1.0"
 dependencies = [
  "bootloader",
  "uart_16550",
- "x86_64 0.13.6",
+ "x86_64",
 ]
 
 [[package]]
@@ -374,7 +368,7 @@ version = "0.1.0"
 dependencies = [
  "bootloader",
  "uart_16550",
- "x86_64 0.13.6",
+ "x86_64",
 ]
 
 [[package]]
@@ -383,7 +377,7 @@ version = "0.1.0"
 dependencies = [
  "bootloader",
  "uart_16550",
- "x86_64 0.13.6",
+ "x86_64",
 ]
 
 [[package]]
@@ -432,7 +426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "503a6c0e6d82daa87985e662d120c0176b09587c92a68db22781b28ae95405dd"
 dependencies = [
  "bitflags",
- "x86_64 0.14.2",
+ "x86_64",
 ]
 
 [[package]]
@@ -441,7 +435,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bad643914094137d475641b6bab89462505316ec2ce70907ad20102d28a79ab8"
 dependencies = [
- "bit_field 0.10.1",
+ "bit_field",
 ]
 
 [[package]]
@@ -530,21 +524,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "x86_64"
-version = "0.13.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021b49a4cb0a0d9490265cc169ca816014cbf61d3f3b75424815912977b81871"
+checksum = "fb611915c917c6296d11e23f71ff1ecfe49c5766daba92cd3df52df6b58285b6"
 dependencies = [
- "bit_field 0.9.0",
- "bitflags",
-]
-
-[[package]]
-name = "x86_64"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f09cffc08ee86bf5e4d147f107a43de0885c53ffad799b39f4ad203fb2a27d"
-dependencies = [
- "bit_field 0.9.0",
+ "bit_field",
  "bitflags",
  "volatile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ required-features = ["uefi_bin"]
 
 [dependencies]
 xmas-elf = { version = "0.6.2", optional = true }
-x86_64 = { version = "0.13.2", optional = true, default-features = false, features = ["instructions", "inline_asm"] }
+x86_64 = { version = "0.14.7", optional = true, default-features = false, features = ["instructions", "inline_asm"] }
 usize_conversions = { version = "0.2.0", optional = true }
 bit_field = { version = "0.10.0", optional = true }
 log = { version = "0.4.8", optional = true }

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix `asm` imports on latest nightly ([#209](https://github.com/rust-osdev/bootloader/pull/209))
+
 # 0.10.9 – 2021-10-07
 
 - Add support for framebuffer configuration ([#179](https://github.com/rust-osdev/bootloader/pull/179))

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 # 0.10.9 – 2021-10-07
 
+- Add support for framebuffer configuration ([#179](https://github.com/rust-osdev/bootloader/pull/179))
+
 # 0.10.8 – 2021-08-22
 
 - Pad UEFI FAT file length ([#180](https://github.com/rust-osdev/bootloader/pull/180))

--- a/examples/test_framework/Cargo.toml
+++ b/examples/test_framework/Cargo.toml
@@ -12,6 +12,6 @@ members = [
 
 [dependencies]
 bootloader = { path = "../.." } # replace this with a version number
-x86_64 = "0.14.2"
+x86_64 = "0.14.7"
 uart_16550 = "0.2.14"
 spin = { version = "0.9.0", features = ["lazy"] }

--- a/src/bin/bios.rs
+++ b/src/bin/bios.rs
@@ -11,8 +11,11 @@ use bootloader::{
     binary::SystemInfo,
     boot_info::{FrameBufferInfo, PixelFormat},
 };
-use core::panic::PanicInfo;
-use core::slice;
+use core::{
+    arch::{asm, global_asm},
+    panic::PanicInfo,
+    slice,
+};
 use usize_conversions::usize_from;
 use x86_64::structures::paging::{FrameAllocator, OffsetPageTable};
 use x86_64::structures::paging::{

--- a/src/bin/uefi.rs
+++ b/src/bin/uefi.rs
@@ -17,7 +17,7 @@ use bootloader::{
     binary::{legacy_memory_region::LegacyFrameAllocator, parsed_config::CONFIG, SystemInfo},
     boot_info::FrameBufferInfo,
 };
-use core::{mem, panic::PanicInfo, slice};
+use core::{arch::asm, mem, panic::PanicInfo, slice};
 use uefi::{
     prelude::{entry, Boot, Handle, ResultExt, Status, SystemTable},
     proto::console::gop::{GraphicsOutput, PixelFormat},

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -3,6 +3,7 @@ use crate::{
     boot_info::{BootInfo, FrameBuffer, FrameBufferInfo, MemoryRegion, TlsTemplate},
 };
 use core::{
+    arch::asm,
     mem::{self, MaybeUninit},
     slice,
 };

--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -1,6 +1,7 @@
 use std::{
+    io::Write,
     path::{Path, PathBuf},
-    process::Command,
+    process::{Command, Stdio},
 };
 
 const QEMU_ARGS: &[&str] = &[
@@ -28,8 +29,11 @@ fn main() {
     run_cmd.args(QEMU_ARGS);
     run_cmd.args(std::env::args().skip(2).collect::<Vec<_>>());
 
-    let exit_status = run_cmd.status().unwrap();
-    match exit_status.code() {
+    let child_output = run_cmd.output().unwrap();
+    std::io::stderr().write_all(&child_output.stderr).unwrap();
+    std::io::stderr().write_all(&child_output.stdout).unwrap();
+
+    match child_output.status.code() {
         Some(33) => {}                     // success
         Some(35) => panic!("Test failed"), // success
         other => panic!("Test failed with unexpected exit code `{:?}`", other),

--- a/tests/test_kernels/default_settings/Cargo.toml
+++ b/tests/test_kernels/default_settings/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 bootloader = { path = "../../.." }
-x86_64 = { version = "0.13.2", default-features = false, features = ["instructions", "inline_asm"] }
+x86_64 = { version = "0.14.7", default-features = false, features = ["instructions", "inline_asm"] }
 uart_16550 = "0.2.10"

--- a/tests/test_kernels/higher_half/Cargo.toml
+++ b/tests/test_kernels/higher_half/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 bootloader = { path = "../../.." }
-x86_64 = { version = "0.13.2", default-features = false, features = ["instructions", "inline_asm"] }
+x86_64 = { version = "0.14.7", default-features = false, features = ["instructions", "inline_asm"] }
 uart_16550 = "0.2.10"

--- a/tests/test_kernels/map_phys_mem/Cargo.toml
+++ b/tests/test_kernels/map_phys_mem/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 bootloader = { path = "../../.." }
-x86_64 = { version = "0.13.2", default-features = false, features = ["instructions", "inline_asm"] }
+x86_64 = { version = "0.14.7", default-features = false, features = ["instructions", "inline_asm"] }
 uart_16550 = "0.2.10"
 
 [package.metadata.bootloader]


### PR DESCRIPTION
The `asm` and `global_asm` macros now live in `core::arch` and are no longer part of the prelude on the latest nightlies.
