### PR TITLE
Remove feature flag for 'lang_items', 'asm' and 'global_asm'

### DIFF
--- a/src/bin/bios.rs
+++ b/src/bin/bios.rs
@@ -1,6 +1,3 @@
-#![feature(lang_items)]
-#![feature(global_asm)]
-#![feature(asm)]
 #![no_std]
 #![no_main]
 

--- a/src/bin/uefi.rs
+++ b/src/bin/uefi.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 #![feature(abi_efiapi)]
-#![feature(asm)]
 #![feature(maybe_uninit_extra)]
 #![deny(unsafe_op_in_unsafe_fn)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,6 @@ for all possible configuration options.
 */
 
 #![cfg_attr(not(feature = "builder"), no_std)]
-#![feature(asm)]
 #![feature(maybe_uninit_extra)]
 #![feature(maybe_uninit_slice)]
 #![deny(unsafe_op_in_unsafe_fn)]

--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -1,7 +1,7 @@
 use std::{
     io::Write,
     path::{Path, PathBuf},
-    process::{Command, Stdio},
+    process::Command,
 };
 
 const QEMU_ARGS: &[&str] = &[


### PR DESCRIPTION
The feature `asm` and `global_asm` are stable since `1.59.0` and activated by default. So I just removed the feature flags to reduce the number of compiler warnings.

The feature flag `lang_items` has been removed as well as it was no longer used.