### PR TITLE
use set_reg method of CS, DS, ES and SS segment structs

### DIFF
--- a/src/binary/gdt.rs
+++ b/src/binary/gdt.rs
@@ -1,5 +1,5 @@
 use x86_64::{
-    instructions::segmentation,
+    instructions::segmentation::{Segment, CS, DS, ES, SS},
     structures::{
         gdt::{Descriptor, GlobalDescriptorTable},
         paging::PhysFrame,
@@ -24,9 +24,9 @@ pub fn create_and_load(frame: PhysFrame) {
 
     gdt.load();
     unsafe {
-        segmentation::set_cs(code_selector);
-        segmentation::load_ds(data_selector);
-        segmentation::load_es(data_selector);
-        segmentation::load_ss(data_selector);
+        CS::set_reg(code_selector);
+        DS::set_reg(data_selector);
+        ES::set_reg(data_selector);
+        SS::set_reg(data_selector);
     }
 }


### PR DESCRIPTION
I switched to the `set_reg` method to set the `SegmentSelector` for `CS`, `DS`, `ES` and `SS`, because `set_cs`, `load_ds`, `load_es` and  `load_ss` are deprecated in the `x86_64` crate.