### PR TITLE
Logger: nicer font rendering into framebuffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,11 +65,11 @@ dependencies = [
  "conquer-once",
  "displaydoc",
  "fatfs",
- "font8x8",
  "gpt",
  "json",
  "llvm-tools",
  "log",
+ "noto-sans-mono-bitmap",
  "proc-macro2",
  "quote",
  "rsdp",
@@ -171,12 +171,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "font8x8"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63201c624b8c8883921b1a1accc8916c4fa9dbfb15d122b26e4dde945b86bbf"
-
-[[package]]
 name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +246,12 @@ checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "noto-sans-mono-bitmap"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5e9cd9598c6cc63547a44c3075b682d37175f3fb4508d3f7fe604ddad6d805"
 
 [[package]]
 name = "num-integer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,10 +52,10 @@ rsdp = { version = "1.0.0", optional = true }
 fatfs = { version = "0.3.4", optional = true }
 gpt = { version = "2.0.0", optional = true }
 
-[dependencies.font8x8]
-version = "0.2.5"
+[dependencies.noto-sans-mono-bitmap]
+version = "0.1.2"
 default-features = false
-features = ["unicode"]
+features = ["regular", "size_14"]
 optional = true
 
 [build-dependencies]
@@ -72,7 +72,7 @@ bios_bin = ["binary", "rsdp"]
 uefi_bin = ["binary", "uefi"]
 binary = [
     "llvm-tools-build", "x86_64", "toml", "xmas-elf", "usize_conversions", "log", "conquer-once",
-    "spinning_top", "serde", "font8x8", "quote", "proc-macro2",
+    "spinning_top", "serde", "noto-sans-mono-bitmap", "quote", "proc-macro2",
 ]
 
 [profile.dev]


### PR DESCRIPTION
This PR removes the ugly 8x8 bitmap font and replaces it by a much nicer alternative: [noto-sans-mono-bitmap](https://crates.io/crates/noto-sans-mono-bitmap). It is similar size efficient (doesn't bloat the binary), no_std compatible, uses zero allocations, and no floating point operations.

## Before:
![image](https://user-images.githubusercontent.com/5737016/150209120-49d0b391-bcd5-4a2f-97f7-7e37fe0da7ef.png)

## After:
![image](https://user-images.githubusercontent.com/5737016/150209141-287aa12d-1b0f-4f94-8a9f-972d9671501f.png)
