### PR TITLE
`maybe_uninit_extra` is no longer feature-gated in Rust 1.60

### DIFF
--- a/src/bin/uefi.rs
+++ b/src/bin/uefi.rs
@@ -1,7 +1,8 @@
 #![no_std]
 #![no_main]
 #![feature(abi_efiapi)]
-#![feature(maybe_uninit_extra)]
+#![feature(cfg_version)]
+#![cfg_attr(not(version("1.60")), feature(maybe_uninit_extra))]
 #![deny(unsafe_op_in_unsafe_fn)]
 
 // Defines the constants `KERNEL_BYTES` (array of `u8`) and `KERNEL_SIZE` (`usize`).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,9 @@ for all possible configuration options.
 */
 
 #![cfg_attr(not(feature = "builder"), no_std)]
-#![feature(maybe_uninit_extra)]
+#![feature(cfg_version)]
+
+#![cfg_attr(not(version("1.60"), feature(maybe_uninit_extra))]
 #![feature(maybe_uninit_slice)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![warn(missing_docs)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ for all possible configuration options.
 #![cfg_attr(not(feature = "builder"), no_std)]
 #![feature(cfg_version)]
 
-#![cfg_attr(not(version("1.60"), feature(maybe_uninit_extra))]
+#![cfg_attr(not(version("1.60")), feature(maybe_uninit_extra))]
 #![feature(maybe_uninit_slice)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![warn(missing_docs)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,6 @@ for all possible configuration options.
 
 #![cfg_attr(not(feature = "builder"), no_std)]
 #![feature(cfg_version)]
-
 #![cfg_attr(not(version("1.60")), feature(maybe_uninit_extra))]
 #![feature(maybe_uninit_slice)]
 #![deny(unsafe_op_in_unsafe_fn)]


### PR DESCRIPTION
With the most current nightlies, the compiler throws warnings when attempts to build boot images is made because of this ― so time to PR this into the tree to fix this problem.