### PR TITLE
Add small doc-comment to `entry_point!` macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,7 @@ compile_error!("This crate only supports the x86_64 architecture.");
 #[macro_export]
 macro_rules! entry_point {
     ($path:path) => {
+        /// Kernel entry point.
         #[export_name = "_start"]
         pub extern "C" fn __impl_start(boot_info: &'static mut $crate::boot_info::BootInfo) -> ! {
             // validate the signature of the program entry point


### PR DESCRIPTION
Without this change, `clippy` will complain

``` TXT
error: missing documentation for a function
  --> src/main.rs:60:1
   |
60 | bootloader::entry_point!(kernel_start);
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
note: the lint level is defined here
  --> src/main.rs:27:9
   |
27 | #![deny(missing_docs)]
   |         ^^^^^^^^^^^^
   = note: this error originates in the macro `bootloader::entry_point` (in Nightly builds, run with -Z macro-backtrace for more info)

error: could not compile `kernel` due to previous error
```

when using `#![deny(clippy::cargo)]` and I cannot compile my kernel.