### PR TITLE
`maybe_uninit_extra` is no longer feature-gated

### DIFF
--- a/src/bin/uefi.rs
+++ b/src/bin/uefi.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 #![feature(abi_efiapi)]
-#![feature(maybe_uninit_extra)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
 // Defines the constants `KERNEL_BYTES` (array of `u8`) and `KERNEL_SIZE` (`usize`).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,6 @@ for all possible configuration options.
 */
 
 #![cfg_attr(not(feature = "builder"), no_std)]
-#![feature(maybe_uninit_extra)]
 #![feature(maybe_uninit_slice)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![warn(missing_docs)]


### PR DESCRIPTION
Per request by @phil-opp in the discussion related to the now-closed pull-request #218, here's a separate PR that redoes the feature-gate removal, this time as an unconditional one.