### PR TITLE
Allow use of `FrameBufferInfo` as a compositing template

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
     "rust-analyzer.checkOnSave.allTargets": false,
-    "rust-analyzer.cargo.target": "x86_64-bootloader.json",
     "rust-analyzer.checkOnSave.extraArgs": [
         "-Zbuild-std=core,alloc"
     ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "rust-analyzer.checkOnSave.allTargets": false,
+    "rust-analyzer.cargo.target": "x86_64-bootloader.json",
     "rust-analyzer.checkOnSave.extraArgs": [
         "-Zbuild-std=core,alloc"
     ]

--- a/src/boot_info.rs
+++ b/src/boot_info.rs
@@ -177,6 +177,15 @@ impl FrameBuffer {
     pub fn info(&self) -> FrameBufferInfo {
         self.info
     }
+
+    /// Creates a new `FrameBuffer` instance using `info` as input
+    pub fn from_info(&self, info: FrameBufferInfo) -> Self {
+        FrameBuffer {
+            buffer_start: self.buffer_start,
+            buffer_byte_len: self.buffer_start as usize + info.byte_len as usize,
+            info: info,
+        }
+    }
 }
 
 /// Describes the layout and pixel format of a framebuffer.

--- a/src/boot_info.rs
+++ b/src/boot_info.rs
@@ -179,10 +179,11 @@ impl FrameBuffer {
     }
 
     /// Creates a new `FrameBuffer` instance using `info` as input
-    pub fn from_info(&self, info: FrameBufferInfo) -> Self {
+    pub fn from_info(&mut self, info: FrameBufferInfo) -> Self {
+        let reflexive_ptr = self.buffer_mut().as_mut_ptr() as usize;
         FrameBuffer {
-            buffer_start: self.buffer_start,
-            buffer_byte_len: self.buffer_start as usize + info.byte_len as usize,
+            buffer_start: reflexive_ptr as u64,
+            buffer_byte_len: reflexive_ptr + info.byte_len as usize,
             info: info,
         }
     }

--- a/src/boot_info.rs
+++ b/src/boot_info.rs
@@ -150,7 +150,7 @@ pub enum MemoryRegionKind {
 }
 
 /// A pixel-based framebuffer that controls the screen output.
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 #[repr(C)]
 pub struct FrameBuffer {
     pub(crate) buffer_start: u64,

--- a/src/boot_info.rs
+++ b/src/boot_info.rs
@@ -178,12 +178,12 @@ impl FrameBuffer {
         self.info
     }
 
-    /// Creates a new `FrameBuffer` instance using `info` as input
-    pub fn from_info(&mut self, info: FrameBufferInfo) -> Self {
-        let reflexive_ptr = self.buffer_mut().as_mut_ptr() as usize;
+    /// Creates a new `FrameBuffer` instance at address `addr` using `info` as input
+    /// Safety: make absolutely certain that `addr` is properly memory-mapped
+    pub unsafe fn from_info(&mut self, addr: u64, info: FrameBufferInfo) -> Self {
         FrameBuffer {
-            buffer_start: reflexive_ptr as u64,
-            buffer_byte_len: reflexive_ptr + info.byte_len as usize,
+            buffer_start: addr,
+            buffer_byte_len: addr as usize + info.byte_len as usize,
             info: info,
         }
     }

--- a/src/boot_info.rs
+++ b/src/boot_info.rs
@@ -150,7 +150,7 @@ pub enum MemoryRegionKind {
 }
 
 /// A pixel-based framebuffer that controls the screen output.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug)]
 #[repr(C)]
 pub struct FrameBuffer {
     pub(crate) buffer_start: u64,
@@ -180,7 +180,8 @@ impl FrameBuffer {
 
     /// Creates a new `FrameBuffer` instance at address `addr` using `info` as input
     /// Safety: make absolutely certain that `addr` is properly memory-mapped
-    pub unsafe fn from_info(&mut self, addr: u64, info: FrameBufferInfo) -> Self {
+    pub unsafe fn from_info(&mut self, loc: *mut FrameBuffer, info: FrameBufferInfo) -> Self {
+        let addr = (loc as usize) as u64;
         FrameBuffer {
             buffer_start: addr,
             buffer_byte_len: addr as usize + info.byte_len as usize,


### PR DESCRIPTION
In order to allow things like compositing, for instance, in kernel mode, the framebuffer must be capable of being duplicated in some way. For example, something like the following is not possible in the current state:

```
pub static COMPOSITING_TABLE: Mutex<Vec<FrameBuffer>> = Mutex::new(Vec::new());
// use embedded_graphics to render entries in multiple distinct buffers stored in this Vec and render them all on top of one another
```
So I'm submitting this PR to allow one to use a given `FrameBufferInfo` struct to allow kernel developers to create a new `FrameBuffer` using the data from the one already present, so said developers can then decorate their own framebuffer copies and merge them down. Should make compositing support on the kernel end that much easier to implement.