### PR TITLE
add UEFI PXE support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
@@ -312,18 +312,18 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
@@ -443,13 +443,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.91"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
+checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -545,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.13.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7363ecc1a80d6a7467b322bfb16e95ac5e19f0b71ba2af3e6592f101820113"
+checksum = "705535cf386e4b033cc7acdea55ec8710f3dde2f07457218791aac35c83be21f"
 dependencies = [
  "bitflags",
  "log",
@@ -557,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "uefi-macros"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7006b85ae8acaf2b448c5f1630a434caaacaedcc0907f12404e4e31c9dafcdb3"
+checksum = "0b9917831bc5abb78c2e6a0f4fba2be165105ed53d288718c999e0efbd433bb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -567,10 +567,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "unicode-ident"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
 
 [[package]]
 name = "usize_conversions"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,8 @@ pub fn create_bios_disk_image(
     Ok(())
 }
 
+/// Prepare a folder for use with booting over UEFI_PXE. The dhcp server should
+/// have the filename option set to `bootloader`.
 pub fn create_uefi_pxe_tftp_folder(kernel_binary: &Path, out_path: &Path) -> anyhow::Result<()> {
     let bootloader_path = Path::new(env!("UEFI_BOOTLOADER_PATH"));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,8 +123,11 @@ pub fn create_bios_disk_image(
     Ok(())
 }
 
-/// Prepare a folder for use with booting over UEFI_PXE. The dhcp server should
-/// have the filename option set to `bootloader`.
+/// Prepare a folder for use with booting over UEFI_PXE.
+///
+/// This places the bootloader executable under the path "bootloader". The
+/// DHCP server should set the filename option to that path, otherwise the
+/// bootloader won't be found.
 pub fn create_uefi_pxe_tftp_folder(kernel_binary: &Path, out_path: &Path) -> anyhow::Result<()> {
     let bootloader_path = Path::new(env!("UEFI_BOOTLOADER_PATH"));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ use std::{
 mod fat;
 mod gpt;
 mod mbr;
+mod pxe;
 
 const KERNEL_FILE_NAME: &str = "kernel-x86_64";
 
@@ -118,6 +119,15 @@ pub fn create_bios_disk_image(
         out_mbr_path,
     )
     .context("failed to create BIOS MBR disk image")?;
+
+    Ok(())
+}
+
+pub fn create_uefi_pxe_tftp_folder(kernel_binary: &Path, out_path: &Path) -> anyhow::Result<()> {
+    let bootloader_path = Path::new(env!("UEFI_BOOTLOADER_PATH"));
+
+    pxe::create_uefi_tftp_folder(bootloader_path, kernel_binary, out_path)
+        .context("failed to create UEFI PXE tftp folder")?;
 
     Ok(())
 }

--- a/src/pxe.rs
+++ b/src/pxe.rs
@@ -1,0 +1,32 @@
+use std::path::Path;
+
+use anyhow::Context;
+
+pub fn create_uefi_tftp_folder(
+    bootloader_path: &Path,
+    kernel_binary: &Path,
+    out_path: &Path,
+) -> anyhow::Result<()> {
+    std::fs::create_dir_all(out_path)
+        .with_context(|| format!("failed to create out dir at {}", out_path.display()))?;
+
+    let to = out_path.join("bootloader");
+    std::fs::copy(bootloader_path, &to).with_context(|| {
+        format!(
+            "failed to copy bootloader from {} to {}",
+            bootloader_path.display(),
+            to.display()
+        )
+    })?;
+
+    let to = out_path.join("kernel-x86_64");
+    std::fs::copy(kernel_binary, &to).with_context(|| {
+        format!(
+            "failed to copy kernel from {} to {}",
+            kernel_binary.display(),
+            to.display()
+        )
+    })?;
+
+    Ok(())
+}

--- a/tests/runner/src/lib.rs
+++ b/tests/runner/src/lib.rs
@@ -53,13 +53,6 @@ pub fn run_test_kernel_on_uefi_pxe(kernel_binary_path: &str) {
 
     bootloader::create_uefi_pxe_tftp_folder(kernel_path, &out_tftp_path).unwrap();
 
-    let out_fat_path = kernel_path.with_extension("fat");
-    bootloader::create_boot_partition(kernel_path, &out_fat_path).unwrap();
-    let out_gpt_path = kernel_path.with_extension("gpt");
-    bootloader::create_uefi_disk_image(&out_fat_path, &out_gpt_path).unwrap();
-    let out_mbr_path = kernel_path.with_extension("mbr");
-    bootloader::create_bios_disk_image(&out_fat_path, &out_mbr_path).unwrap();
-
     let mut run_cmd = Command::new("qemu-system-x86_64");
     run_cmd.arg("-netdev").arg(format!(
         "user,id=net0,net=192.168.17.0/24,tftp={},bootfile=bootloader,id=net0",

--- a/tests/runner/src/lib.rs
+++ b/tests/runner/src/lib.rs
@@ -11,6 +11,12 @@ const QEMU_ARGS: &[&str] = &[
 ];
 
 pub fn run_test_kernel(kernel_binary_path: &str) {
+    run_test_kernel_on_uefi(kernel_binary_path);
+    run_test_kernel_on_uefi_pxe(kernel_binary_path);
+    // TODO: run tests with BIOS bootloader too
+}
+
+pub fn run_test_kernel_on_uefi(kernel_binary_path: &str) {
     let kernel_path = Path::new(kernel_binary_path);
     let out_fat_path = kernel_path.with_extension("fat");
     bootloader::create_boot_partition(kernel_path, &out_fat_path).unwrap();
@@ -19,12 +25,47 @@ pub fn run_test_kernel(kernel_binary_path: &str) {
     let out_mbr_path = kernel_path.with_extension("mbr");
     bootloader::create_bios_disk_image(&out_fat_path, &out_mbr_path).unwrap();
 
-    // TODO: run tests with BIOS bootloader too
-
     let mut run_cmd = Command::new("qemu-system-x86_64");
     run_cmd
         .arg("-drive")
         .arg(format!("format=raw,file={}", out_gpt_path.display()));
+    run_cmd.args(QEMU_ARGS);
+    run_cmd.arg("-bios").arg(ovmf_prebuilt::ovmf_pure_efi());
+
+    let child_output = run_cmd.output().unwrap();
+    strip_ansi_escapes::Writer::new(std::io::stderr())
+        .write_all(&child_output.stderr)
+        .unwrap();
+    strip_ansi_escapes::Writer::new(std::io::stderr())
+        .write_all(&child_output.stdout)
+        .unwrap();
+
+    match child_output.status.code() {
+        Some(33) => {}                     // success
+        Some(35) => panic!("Test failed"), // success
+        other => panic!("Test failed with unexpected exit code `{:?}`", other),
+    }
+}
+
+pub fn run_test_kernel_on_uefi_pxe(kernel_binary_path: &str) {
+    let kernel_path = Path::new(kernel_binary_path);
+    let out_tftp_path = kernel_path.with_extension(".tftp");
+
+    bootloader::create_uefi_pxe_tftp_folder(kernel_path, &out_tftp_path).unwrap();
+
+    let out_fat_path = kernel_path.with_extension("fat");
+    bootloader::create_boot_partition(kernel_path, &out_fat_path).unwrap();
+    let out_gpt_path = kernel_path.with_extension("gpt");
+    bootloader::create_uefi_disk_image(&out_fat_path, &out_gpt_path).unwrap();
+    let out_mbr_path = kernel_path.with_extension("mbr");
+    bootloader::create_bios_disk_image(&out_fat_path, &out_mbr_path).unwrap();
+
+    let mut run_cmd = Command::new("qemu-system-x86_64");
+    run_cmd.arg("-netdev").arg(format!(
+        "user,id=net0,net=192.168.17.0/24,tftp={},bootfile=bootloader,id=net0",
+        out_tftp_path.display()
+    ));
+    run_cmd.arg("-device").arg("virtio-net-pci,netdev=net0");
     run_cmd.args(QEMU_ARGS);
     run_cmd.arg("-bios").arg(ovmf_prebuilt::ovmf_pure_efi());
 

--- a/tests/runner/src/lib.rs
+++ b/tests/runner/src/lib.rs
@@ -78,8 +78,8 @@ pub fn run_test_kernel_on_uefi_pxe(kernel_binary_path: &str) {
         .unwrap();
 
     match child_output.status.code() {
-        Some(33) => {}                     // success
-        Some(35) => panic!("Test failed"), // success
+        Some(33) => {} // success
+        Some(35) => panic!("Test failed"),
         other => panic!("Test failed with unexpected exit code `{:?}`", other),
     }
 }

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -11,5 +11,5 @@ license = "MIT/Apache-2.0"
 bootloader_api = { version = "0.1.0-alpha.0", path = "../api" }
 bootloader-x86_64-common = { version = "0.1.0-alpha.0", path = "../common" }
 log = "0.4.14"
-uefi = "0.13.0"
+uefi = "0.16.0"
 x86_64 = "0.14.8"


### PR DESCRIPTION
This pr implements a UEFI PXE bootloader by extending the existing UEFI bootloader to load a kernel from a TFTP server if the DevicePath of the LoadedImage has a device implementing PXE BaseCode protocol.

~~This pr needs some [unreleased new features](https://github.com/rust-osdev/uefi-rs/pull/417) of the `uefi-rs` crate, so we'll have to wait for a new release before merging this branch (I switched the `uefi-rs` dependency to use the master branch for now). This is the reason I'm marking the pr as a draft.~~

Related to #87