### PR TITLE
mitigate undefined symbol _fltused

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,3 +127,7 @@ macro_rules! entry_point {
         }
     };
 }
+
+#[used]
+#[no_mangle]
+pub static _fltused: i32 = 0;


### PR DESCRIPTION
This hopefully fixes the build until the issue is resolved in the linker.

Ref rust-lang/rust#62785