### PR TITLE
[Logger] Don't panic if unsupported char

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ rand = { version = "0.8.4", optional = true, default-features = false }
 rand_chacha = { version = "0.3.1", optional = true, default-features = false }
 
 [dependencies.noto-sans-mono-bitmap]
-version = "0.1.2"
+version = "0.1.6"
 default-features = false
 features = ["regular", "size_14"]
 optional = true

--- a/src/binary/logger.rs
+++ b/src/binary/logger.rs
@@ -108,7 +108,10 @@ impl Logger {
                 if self.y_pos >= (self.height() - BITMAP_LETTER_WIDTH) {
                     self.clear();
                 }
-                let bitmap_char = get_bitmap(c, FontWeight::Regular, BitmapHeight::Size14).unwrap();
+                let bitmap_char = get_bitmap(c, FontWeight::Regular, BitmapHeight::Size14)
+                    .unwrap_or(
+                        get_bitmap('■', FontWeight::Regular, BitmapHeight::Size14).unwrap()
+                    );
                 self.write_rendered_char(bitmap_char);
             }
         }


### PR DESCRIPTION
Hello,

Currently, when we print a char in the screen if it is unsupported on noto-sans-mono-bitmap it panics.
Now the noto-sans-mono-bitmap supports the '■' char, we can use it instead of panicking.

Changes included in this PR:
    - Update noto-sans-mono-bitmap (Cargo.toml)
    - Don't panic if an unsupported char is found (src/binary/logger.rs)

Thanks!