### PR TITLE
Include `llvm-tools-preview` in `rust-toolchain.toml`

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,0 @@
-nightly

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "nightly"
+components = [
+    "llvm-tools-preview",
+]


### PR DESCRIPTION
Building the bootloader test and example kernels requires the `llvm-tools-preview` Rust toolchain component to be installed. Rustup can automatically install additional toolchain components if the `rust-toolchain` file includes a `components` section.

This commit adds a configuration in the `rust-toolchain` file to tell Rustup to install `llvm-tools-preview` automatically. This requires switching the toolchain file from the legacy format to [the TOML format]. Therefore, I've also renamed the file from `rust-toolchain` to `rust-toolchain.toml`, so that it gets highlighted as a TOML file by most editors by default.

[the TOML format]: https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file