### PR TITLE
Use choco instead of scoop for installing QEMU on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,14 +65,10 @@ jobs:
         HOMEBREW_NO_AUTO_UPDATE: 1
         HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: 1
         HOMEBREW_NO_INSTALL_CLEANUP: 1
-    - name: Install Scoop (Windows)
-      run: |
-        Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
-        echo "$HOME\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      if: runner.os == 'Windows'
-      shell: pwsh
     - name: Install QEMU (Windows)
-      run: scoop install qemu
+      run: |
+        choco install qemu --version 2021.5.5
+        echo "$Env:Programfiles\qemu" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       if: runner.os == 'Windows'
       shell: pwsh
     - name: "Print QEMU Version"


### PR DESCRIPTION
The following error occurs on CI with the latest version of scoop now:

> Running the installer as administrator is disabled by default, see https://github.com/ScoopInstaller/Install#for-admin for details.

This PR fixes this CI error by switching to `choco`, which we're already using on the `main` branch.