### PR TITLE
fb/logger: bump noto-sans-mono-bitmap + improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "noto-sans-mono-bitmap"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5e9cd9598c6cc63547a44c3075b682d37175f3fb4508d3f7fe604ddad6d805"
+checksum = "a27daf9557165efe1d09b52f97393bf6283cadb0a76fbe64a1061e15553a994a"
 
 [[package]]
 name = "num-integer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,17 +56,23 @@ rand = { version = "0.8.4", optional = true, default-features = false }
 rand_chacha = { version = "0.3.1", optional = true, default-features = false }
 
 [dependencies.noto-sans-mono-bitmap]
-version = "0.1.2"
+version = "0.2.0"
 default-features = false
-features = ["regular", "size_14"]
+features = [
+    "regular",
+    "size_16",
+    "unicode-basic-latin",
+    # required for the fallback char '�'
+    "unicode-specials"
+]
 optional = true
 
 [build-dependencies]
 llvm-tools-build = { version = "0.1", optional = true, package = "llvm-tools" }
 toml = { version = "0.5.1", optional = true }
-serde = { version = "1.0", features = ["derive"], optional = true}
-quote = { version = "1.0", optional = true}
-proc-macro2 = { version = "1.0", optional = true}
+serde = { version = "1.0", features = ["derive"], optional = true }
+quote = { version = "1.0", optional = true }
+proc-macro2 = { version = "1.0", optional = true }
 
 [features]
 default = []
@@ -94,6 +100,6 @@ default-target = "x86_64-unknown-linux-gnu"
 [package.metadata.release]
 dev-version = false
 pre-release-replacements = [
-    { file="Changelog.md", search="# Unreleased", replace="# Unreleased\n\n# {{version}} – {{date}}", exactly=1 },
+    { file = "Changelog.md", search = "# Unreleased", replace = "# Unreleased\n\n# {{version}} – {{date}}", exactly = 1 },
 ]
 pre-release-commit-message = "Release version {{version}}"


### PR DESCRIPTION
Hi,

### Update
This is now ready for merge.

----
### Original Post

I'm the author of the [noto-sans-mono-bitmap](https://github.com/phip1611/noto-sans-mono-bitmap-rs/)-crate and about to release `0.2.0` with breaking changes and many improvements ([CHANGELOG](https://github.com/phip1611/noto-sans-mono-bitmap-rs/blob/main/CHANGELOG.md)).

As the bootloader crate is the only/the biggest user, I'd like to leave room for API discussions before I release the crate.

This MR bumps the `noto-sans-mono-bitmap` to 0.2.0 (unreleased yet) and performs several other small improvements to the framebuffer logger.

Any comments? If there are no comments, I'll release the crate in 2-4 days and switch this MR from draft state to ready

What's new?
- more unicode ranges and they are selectable as cargo features 
- the internal structure was refactored by a lot which enables crate users to better specify which features they want and which they do not want
- the API changed along with the documentation to better fit the use case

**Example**
Please note the `�` fallback character in the `BIOS boot` logging message, which is also new.
![image](https://user-images.githubusercontent.com/5737016/193405017-9ccaeadc-e08a-4e25-99e3-ebea09cb559a.png)


