### PR TITLE
Fix docs: artifact dependency path needs to be accessed using `env::var_os` instead of `env!`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To combine your kernel with a bootloader and create a bootable disk image, follo
   bindeps = true
   ```
   Alternatively, you can use [`std::process::Command`](https://doc.rust-lang.org/stable/std/process/struct.Command.html) to invoke the build command of your kernel in the `build.rs` script. 
-- Obtain the path to the kernel executable. When using an artifact dependency, you can retrieve this path using `env!("CARGO_BIN_FILE_MY_KERNEL_my-kernel")`
+- Obtain the path to the kernel executable. When using an artifact dependency, you can retrieve this path using `std::env::var_os("CARGO_BIN_FILE_MY_KERNEL_my-kernel")`
 - Use `bootloader::UefiBoot` and/or `bootloader::BiosBoot` to create a bootable disk image with your kernel.
 - Do something with the bootable disk images in your `main.rs` function. For example, run them with QEMU.
 

--- a/docs/create-disk-image.md
+++ b/docs/create-disk-image.md
@@ -40,10 +40,10 @@ members = ["kernel"]
 
 fn main() {
     // set by cargo, build scripts should use this directory for output files
-    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let out_dir = std::env::var_os("OUT_DIR").unwrap();
     // set by cargo's artifact dependency feature, see
     // https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#artifact-dependencies
-    let kernel = env!("CARGO_BIN_FILE_KERNEL_kernel");
+    let kernel = std::env::var_os("CARGO_BIN_FILE_KERNEL_kernel");
 
     // create an UEFI disk image (optional)
     let uefi_path = out_dir.join("uefi.img");


### PR DESCRIPTION
Artifact dependencies are available through the `env!` macro only in binaries/libraries. In build scripts, the env variable is set at runtime instead.

Fixes #295 