### PR TITLE
Fix Create Disk Image Example

### DIFF
--- a/docs/create-disk-image.md
+++ b/docs/create-disk-image.md
@@ -29,7 +29,7 @@ test-kernel = { path = "kernel", artifact = "bin", target = "x86_64-unknown-none
 
 [dependencies]
 # used for UEFI booting in QEMU
-ovmf_prebuilt = "0.1.0-alpha.1"
+ovmf-prebuilt = "0.1.0-alpha.1"
 
 [workspace]
 members = ["kernel"]

--- a/docs/create-disk-image.md
+++ b/docs/create-disk-image.md
@@ -38,14 +38,14 @@ members = ["kernel"]
 ```rust
 // build.rs
 
-use std::path::Path;
+use std::path::PathBuf;
 
 fn main() {
     // set by cargo, build scripts should use this directory for output files
-    let out_dir = Path::new(&std::env::var_os("OUT_DIR").unwrap());
+    let out_dir = PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
     // set by cargo's artifact dependency feature, see
     // https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#artifact-dependencies
-    let kernel = Path::new(&std::env::var_os("CARGO_BIN_FILE_KERNEL_kernel").unwrap());
+    let kernel = PathBuf::from(std::env::var_os("CARGO_BIN_FILE_KERNEL_kernel").unwrap());
 
     // create an UEFI disk image (optional)
     let uefi_path = out_dir.join("uefi.img");

--- a/docs/create-disk-image.md
+++ b/docs/create-disk-image.md
@@ -42,24 +42,18 @@ use std::path::Path;
 
 fn main() {
     // set by cargo, build scripts should use this directory for output files
-    let out_dir = std::env::var_os("OUT_DIR").unwrap();
-    let out_dir_path = Path::new(&out_dir);
+    let out_dir = Path::new(&std::env::var_os("OUT_DIR").unwrap());
     // set by cargo's artifact dependency feature, see
     // https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#artifact-dependencies
-    let kernel = std::env::var_os("CARGO_BIN_FILE_KERNEL_kernel").unwrap();
-    let kernel_path = Path::new(&kernel);
+    let kernel = Path::new(&std::env::var_os("CARGO_BIN_FILE_KERNEL_kernel").unwrap());
 
     // create an UEFI disk image (optional)
-    let uefi_path = out_dir_path.join("uefi.img");
-    bootloader::UefiBoot::new(&kernel_path)
-        .create_disk_image(&uefi_path)
-        .unwrap();
+    let uefi_path = out_dir.join("uefi.img");
+    bootloader::UefiBoot::new(&kernel).create_disk_image(&uefi_path).unwrap();
 
     // create a BIOS disk image
-    let bios_path = out_dir_path.join("bios.img");
-    bootloader::BiosBoot::new(&kernel_path)
-        .create_disk_image(&bios_path)
-        .unwrap();
+    let bios_path = out_dir.join("bios.img");
+    bootloader::BiosBoot::new(&kernel).create_disk_image(&bios_path).unwrap();
 
     // pass the disk image paths as env variables to the `main.rs`
     println!("cargo:rustc-env=UEFI_PATH={}", uefi_path.display());


### PR DESCRIPTION
The example code didn't compile. This patch fixes that.

Let me know if it needs any changes, and thanks for making this awesome crate!