### PR TITLE
Limit CI runs to 4 threads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Run api tests
         run: cargo test -p bootloader_api
       - name: Run integration tests
-        run: cargo test
+        run: cargo test -- --test-threads=4
 
   fmt:
     name: Check Formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v3
@@ -60,7 +60,7 @@ jobs:
       - name: Run api tests
         run: cargo test -p bootloader_api
       - name: Run integration tests
-        run: cargo test -- --test-threads=4
+        run: cargo test -- --test-threads=1
 
   fmt:
     name: Check Formatting


### PR DESCRIPTION
During CI/CD runs of #307 the number of parallel tests was having an impact on overall execution time.
In order to improve performance, this updates the github actions to limit test threads to 4.

This was previously the effective limit, as no test file had more than 4 tests in it.

Fixes #310 