### PR TITLE
Correctly allocate last frame in memory descriptor

### DIFF
--- a/common/src/legacy_memory_region.rs
+++ b/common/src/legacy_memory_region.rs
@@ -68,7 +68,7 @@ where
             self.next_frame = start_frame;
         }
 
-        if self.next_frame < end_frame {
+        if self.next_frame <= end_frame {
             let ret = self.next_frame;
             self.next_frame += 1;
             Some(ret)


### PR DESCRIPTION
`end_frame` is inclusive.

Signed-off-by: Klim Tsoutsman <klim@tsoutsman.com>