### PR TITLE
Modify lifetimes in buffer and buffer_mut methods

### DIFF
--- a/api/src/info.rs
+++ b/api/src/info.rs
@@ -177,12 +177,12 @@ impl FrameBuffer {
     }
 
     /// Returns the raw bytes of the framebuffer as slice.
-    pub fn buffer(&self) -> &[u8] {
+    pub fn buffer<'a>(&self) -> &'a [u8] {
         unsafe { self.create_buffer() }
     }
 
     /// Returns the raw bytes of the framebuffer as mutable slice.
-    pub fn buffer_mut(&mut self) -> &mut [u8] {
+    pub fn buffer_mut<'a>(&mut self) -> &'a mut [u8] {
         unsafe { self.create_buffer_mut() }
     }
 


### PR DESCRIPTION
Hello,

I had a problem related to lifetimes when I was adding support for the logger in my kernel. I got E0597. Framebuffer must outlive 'static. This was strange for me because the logger code is same that is in the bootloader. But I noticed that the methods buffer() and buffer_mut don't use any lifetime.

With this lifetime annotation in the both methods it works.

Thanks.