### PR TITLE
Cancel in progress PR builds when a new commit is pushed for that PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   schedule:
     - cron: "40 5 * * *" # every day at 5:40
 
+# This causes PR pushes to cancel previous builds, but does not impact cron jobs due to use of .ref, which will have the commit.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     name: Check


### PR DESCRIPTION
I've been chewing through actions time on rust-osdev, I'd prefer to be a good citizen so this will cancel in progress builds on PRs when a new commit is pushed.

It does not impact main, or cron builds, due to the fallback to github.ref