### PR TITLE
Remove dependency on `time` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,19 +267,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "time",
- "winapi",
-]
-
-[[package]]
 name = "concurrent-queue"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,7 +331,6 @@ checksum = "e18f80a87439240dac45d927fd8f8081b6f1e34c03e97271189fa8a8c2e96c8f"
 dependencies = [
  "bitflags",
  "byteorder",
- "chrono",
  "log",
 ]
 
@@ -571,25 +557,6 @@ name = "noto-sans-mono-bitmap"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a27daf9557165efe1d09b52f97393bf6283cadb0a76fbe64a1061e15553a994a"
-
-[[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "ovmf-prebuilt"
@@ -954,16 +921,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
     "tests/test_kernels/higher_half",
     "tests/test_kernels/pie",
     "tests/test_kernels/lto",
-    "tests/test_kernels/ramdisk"
+    "tests/test_kernels/ramdisk",
 ]
 exclude = ["examples/basic", "examples/test_framework"]
 
@@ -45,7 +45,10 @@ uefi = ["dep:gpt", "bootloader_test_runner/uefi"]
 
 [dependencies]
 anyhow = "1.0.32"
-fatfs = "0.3.4"
+fatfs = { version = "0.3.4", default-features = false, features = [
+    "std",
+    "alloc",
+] }
 tempfile = "3.3.0"
 mbrman = { version = "0.5.1", optional = true }
 gpt = { version = "3.0.0", optional = true }


### PR DESCRIPTION
Version 0.1 of the `time` crate has a vulnerability. Apparently it does not affect the `chrono` crate, which is the crate that depends on `time`, but it's better to be safe. We don't actually need the default `chrono` feature of `fatfs`, so we can easily remove both `chrono` and `time` from our dependency tree by disabling that feature.
