### PR TITLE
Fix: treat `kernel_slice_end` as an exclusive bound when checking for overlaps

### DIFF
--- a/common/src/legacy_memory_region.rs
+++ b/common/src/legacy_memory_region.rs
@@ -160,7 +160,7 @@ where
             let kernel_slice_end = kernel_slice_start + kernel_slice_len;
             if region.kind == MemoryRegionKind::Usable
                 && kernel_slice_start < region.end
-                && kernel_slice_end >= region.start
+                && kernel_slice_end > region.start
             {
                 // region overlaps with kernel -> we might need to split it
 


### PR DESCRIPTION
Fixes an error that occured when the exclusive kernel end address was equal to the start address of the next memory region. We erroneously considered these regions as overlapping.
