### PR TITLE
Map BIOS stage-4 at lower address to avoid conflicts with the kernel

### DIFF
--- a/bios/stage-2/src/main.rs
+++ b/bios/stage-2/src/main.rs
@@ -24,9 +24,12 @@ mod vesa;
 /// We use this partition type to store the second bootloader stage;
 const BOOTLOADER_SECOND_STAGE_PARTITION_TYPE: u8 = 0x20;
 
-const STAGE_3_DST: *mut u8 = 0x0010_0000 as *mut u8; // 1MiB (typically 14MiB accessible here)
-const STAGE_4_DST: *mut u8 = 0x0020_0000 as *mut u8; // 2MiB (typically still 13MiB accessible here)
-const KERNEL_DST: *mut u8 = 0x0100_0000 as *mut u8; // 16MiB
+// 1MiB (typically 14MiB accessible here)
+const STAGE_3_DST: *mut u8 = 0x0010_0000 as *mut u8;
+// must match the start address in bios/stage-4/stage-4-link.ld
+const STAGE_4_DST: *mut u8 = 0x0013_0000 as *mut u8;
+// 16MiB
+const KERNEL_DST: *mut u8 = 0x0100_0000 as *mut u8;
 
 static mut DISK_BUFFER: AlignedArrayBuffer<0x4000> = AlignedArrayBuffer {
     buffer: [0; 0x4000],

--- a/bios/stage-4/stage-4-link.ld
+++ b/bios/stage-4/stage-4-link.ld
@@ -1,7 +1,8 @@
 ENTRY(_start)
 
 SECTIONS {
-    . = 0x00200000;
+    # must match STAGE_4_DST address in bios/stage-2/src/main.rs
+    . = 0x00130000;
 
     .start : {
         *(.start)


### PR DESCRIPTION
Parts of stage-4 need to be identity-mapped. This can lead to 'page already mapped' errors when the kernel already occupies the virtual address corresponding to the physical address of the stage-4. For example, a typical virtual start address of the kernel is 2MiB. This was where we placed the stage-4 in physical memory before. This commit avoids that conflict by keeping the stage-4 below the 2MiB boundary.

Fixes #331 