### PR TITLE
Test framework: Don't inherit `stdin` when spawning QEMU

### DIFF
--- a/tests/runner/src/lib.rs
+++ b/tests/runner/src/lib.rs
@@ -124,6 +124,7 @@ where
 
     run_cmd.stdout(Stdio::piped());
     run_cmd.stderr(Stdio::piped());
+    run_cmd.stdin(Stdio::null());
 
     let mut child = run_cmd.spawn().unwrap();
 


### PR DESCRIPTION
Fixes #338 