### PR TITLE
Minor improvements to `BootConfig`

### DIFF
--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 /// Configures the boot behavior of the bootloader.
 #[derive(Serialize, Deserialize)]
 #[serde(default)]
+#[non_exhaustive]
 pub struct BootConfig {
     /// Configuration for the frame buffer setup.
     pub frame_buffer: FrameBuffer,

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -2,27 +2,29 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Configures the boot behavior of the bootloader.
 #[derive(Serialize, Deserialize)]
 #[serde(default)]
 pub struct BootConfig {
-    /// Configuration for the frame buffer that can be used by the kernel to display pixels
-    /// on the screen.
+    /// Configuration for the frame buffer setup.
     pub frame_buffer: FrameBuffer,
 
-    /// Configuration for changing the level of the filter of the messages that are shown in the
-    /// screen when booting. The default is 'Trace'.
+    /// The minimum log level that is printed to the screen during boot.
+    ///
+    /// The default is [`LevelFilter::Trace`].
     pub log_level: LevelFilter,
 
-    /// Whether the bootloader should print log messages to the framebuffer when booting.
+    /// Whether the bootloader should print log messages to the framebuffer during boot.
     ///
     /// Enabled by default.
     pub frame_buffer_logging: bool,
 
-    /// Whether the bootloader should print log messages to the serial port when booting.
+    /// Whether the bootloader should print log messages to the serial port during boot.
     ///
     /// Enabled by default.
     pub serial_logging: bool,
 
+    #[doc(hidden)]
     pub _test_sentinel: u64,
 }
 

--- a/tests/config_file.rs
+++ b/tests/config_file.rs
@@ -13,13 +13,10 @@ fn default_config() {
 
 #[test]
 fn custom_boot_config() {
-    let config = BootConfig {
-        frame_buffer: Default::default(),
-        log_level: Default::default(),
-        frame_buffer_logging: false,
-        serial_logging: true,
-        _test_sentinel: 0xb001b001b001,
-    };
+    let mut config = BootConfig::default();
+    config.frame_buffer_logging = false;
+    config.serial_logging = true;
+    config._test_sentinel = 0xb001b001b001;
     run_test_kernel_internal(
         env!("CARGO_BIN_FILE_TEST_KERNEL_CONFIG_FILE_custom_config"),
         None,


### PR DESCRIPTION
- Improve docs of `BootConfig` struct
- Make `BootConfig` non-exhaustive
