### PR TITLE
Release version `0.11.1`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,10 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
+      - run: cargo publish -p bootloader-boot-config
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
       - run: cargo publish -p bootloader-x86_64-bios-common
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "async-process",
@@ -173,22 +173,22 @@ dependencies = [
 
 [[package]]
 name = "bootloader-boot-config"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bootloader-x86_64-bios-boot-sector"
-version = "0.11.0"
+version = "0.11.1"
 
 [[package]]
 name = "bootloader-x86_64-bios-common"
-version = "0.11.0"
+version = "0.11.1"
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-2"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "byteorder",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-3"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "noto-sans-mono-bitmap 0.1.6",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-4"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-bios-common",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-common"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bootloader-boot-config",
  "bootloader_api",
@@ -239,7 +239,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-uefi"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-common",
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader_api"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "rand",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,15 +31,15 @@ exclude = ["examples/basic", "examples/test_framework"]
 
 [workspace.package]
 # don't forget to update `workspace.dependencies` below
-version = "0.11.0"
+version = "0.11.1"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-osdev/bootloader"
 
 [workspace.dependencies]
-bootloader_api = { version = "0.11.0", path = "api" }
-bootloader-x86_64-common = { version = "0.11.0", path = "common" }
-bootloader-boot-config = { version = "0.11.0", path = "common/config" }
-bootloader-x86_64-bios-common = { version = "0.11.0", path = "bios/common" }
+bootloader_api = { version = "0.11.1", path = "api" }
+bootloader-x86_64-common = { version = "0.11.1", path = "common" }
+bootloader-boot-config = { version = "0.11.1", path = "common/config" }
+bootloader-x86_64-bios-common = { version = "0.11.1", path = "bios/common" }
 
 [features]
 default = ["bios", "uefi"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ fatfs = { version = "0.3.4", default-features = false, features = [
 tempfile = "3.3.0"
 mbrman = { version = "0.5.1", optional = true }
 gpt = { version = "3.0.0", optional = true }
-bootloader-boot-config = { version = "0.11.0", path = "common/config" }
+bootloader-boot-config = { workspace = true }
 serde_json = "1.0.91"
 
 [dev-dependencies]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,34 @@
 # Unreleased
 
+## Features
+
+* [Load ramdisk feature](https://github.com/rust-osdev/bootloader/pull/302)
+* [Support higher half position independent kernels](https://github.com/rust-osdev/bootloader/pull/289)
+- New `set_boot_config` method to configure the boot process (frame buffer dimensions and log output). This is the result of a set of PRs:
+  - [Log level feature](https://github.com/rust-osdev/bootloader/pull/303)
+  - [Improve Logging](https://github.com/rust-osdev/bootloader/pull/314)
+  - [Add support for a configuration file](https://github.com/rust-osdev/bootloader/pull/326)
+  - [Fix loading of boot configuration](https://github.com/rust-osdev/bootloader/pull/342)
+  - [Minor improvements to `BootConfig`](https://github.com/rust-osdev/bootloader/pull/349)
+- [Add `bios` and `uefi` cargo features](https://github.com/rust-osdev/bootloader/pull/304)
+- Boot Info: [Add a `FrameBuffer::into_buffer` method for taking ownership](https://github.com/rust-osdev/bootloader/pull/319)
+* [Simplified disk builder](https://github.com/rust-osdev/bootloader/pull/320)
+
+## Fixes
+- [Correctly allocate last frame in memory descriptor](https://github.com/rust-osdev/bootloader/pull/316)
+- [Correctness fixes for stage2](https://github.com/rust-osdev/bootloader/pull/328)
+- [Fix: treat `kernel_slice_end` as an exclusive bound when checking for overlaps](https://github.com/rust-osdev/bootloader/pull/334)
+* [Map BIOS stage-4 at lower address to avoid conflicts with the kernel](https://github.com/rust-osdev/bootloader/pull/337)
+* [Create kernel stack with correct size and set up a guard page](https://github.com/rust-osdev/bootloader/pull/335)
+
+## Other improvements
+- [Implement faster bios builds](https://github.com/rust-osdev/bootloader/pull/324)
+- [Remove dependency on `time` crate](https://github.com/rust-osdev/bootloader/pull/332)
+- [Fix warnings from Clippy](https://github.com/rust-osdev/bootloader/pull/336)
+* [Make a link in the documentation clickable](https://github.com/rust-osdev/bootloader/pull/341)
+* [Fix spelling and add a check](https://github.com/rust-osdev/bootloader/pull/340)
+* [Run cargo update](https://github.com/rust-osdev/bootloader/pull/347)
+
 # 0.11.0 – 2022-12-01
 
 Major rewrite of the `bootloader` crate with various breaking changes:

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.11.1 – 2023-03-12
+
 ## Features
 
 * [Load ramdisk feature](https://github.com/rust-osdev/bootloader/pull/302)


### PR DESCRIPTION
## Features

* [Load ramdisk feature](https://github.com/rust-osdev/bootloader/pull/302)
* [Support higher half position independent kernels](https://github.com/rust-osdev/bootloader/pull/289)
- New `set_boot_config` method to configure the boot process (frame buffer dimensions and log output). This is the result of a set of PRs:
  - [Log level feature](https://github.com/rust-osdev/bootloader/pull/303)
  - [Improve Logging](https://github.com/rust-osdev/bootloader/pull/314)
  - [Add support for a configuration file](https://github.com/rust-osdev/bootloader/pull/326)
  - [Fix loading of boot configuration](https://github.com/rust-osdev/bootloader/pull/342)
  - [Minor improvements to `BootConfig`](https://github.com/rust-osdev/bootloader/pull/349)
- [Add `bios` and `uefi` cargo features](https://github.com/rust-osdev/bootloader/pull/304)
- Boot Info: [Add a `FrameBuffer::into_buffer` method for taking ownership](https://github.com/rust-osdev/bootloader/pull/319)
* [Simplified disk builder](https://github.com/rust-osdev/bootloader/pull/320)

## Fixes
- [Correctly allocate last frame in memory descriptor](https://github.com/rust-osdev/bootloader/pull/316)
- [Correctness fixes for stage2](https://github.com/rust-osdev/bootloader/pull/328)
- [Fix: treat `kernel_slice_end` as an exclusive bound when checking for overlaps](https://github.com/rust-osdev/bootloader/pull/334)
* [Map BIOS stage-4 at lower address to avoid conflicts with the kernel](https://github.com/rust-osdev/bootloader/pull/337)
* [Create kernel stack with correct size and set up a guard page](https://github.com/rust-osdev/bootloader/pull/335)

## Other improvements
- [Implement faster bios builds](https://github.com/rust-osdev/bootloader/pull/324)
- [Remove dependency on `time` crate](https://github.com/rust-osdev/bootloader/pull/332)
- [Fix warnings from Clippy](https://github.com/rust-osdev/bootloader/pull/336)
* [Make a link in the documentation clickable](https://github.com/rust-osdev/bootloader/pull/341)
* [Fix spelling and add a check](https://github.com/rust-osdev/bootloader/pull/340)
* [Run cargo update](https://github.com/rust-osdev/bootloader/pull/347)
