### PR TITLE
Release `v0.11.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-process",
@@ -173,22 +173,22 @@ dependencies = [
 
 [[package]]
 name = "bootloader-boot-config"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bootloader-x86_64-bios-boot-sector"
-version = "0.11.1"
+version = "0.11.2"
 
 [[package]]
 name = "bootloader-x86_64-bios-common"
-version = "0.11.1"
+version = "0.11.2"
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-2"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "byteorder",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-3"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "noto-sans-mono-bitmap 0.1.6",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-4"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-bios-common",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-common"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "bootloader-boot-config",
  "bootloader_api",
@@ -239,7 +239,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-uefi"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-common",
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader_api"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "rand",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,15 +31,15 @@ exclude = ["examples/basic", "examples/test_framework"]
 
 [workspace.package]
 # don't forget to update `workspace.dependencies` below
-version = "0.11.1"
+version = "0.11.2"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-osdev/bootloader"
 
 [workspace.dependencies]
-bootloader_api = { version = "0.11.1", path = "api" }
-bootloader-x86_64-common = { version = "0.11.1", path = "common" }
-bootloader-boot-config = { version = "0.11.1", path = "common/config" }
-bootloader-x86_64-bios-common = { version = "0.11.1", path = "bios/common" }
+bootloader_api = { version = "0.11.2", path = "api" }
+bootloader-x86_64-common = { version = "0.11.2", path = "common" }
+bootloader-boot-config = { version = "0.11.2", path = "common/config" }
+bootloader-x86_64-bios-common = { version = "0.11.2", path = "bios/common" }
 
 [features]
 default = ["bios", "uefi"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ bootloader-x86_64-bios-common = { version = "0.11.1", path = "bios/common" }
 
 [features]
 default = ["bios", "uefi"]
-bios = ["dep:mbrman", "bootloader_test_runner/bios"]
-uefi = ["dep:gpt", "bootloader_test_runner/uefi"]
+bios = ["dep:mbrman"]
+uefi = ["dep:gpt"]
 
 [dependencies]
 anyhow = "1.0.32"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 0.11.2 – 2023-03-12
+
+- Fix internal error in Cargo.toml setup that prevented publishing 0.11.1
+
 # 0.11.1 – 2023-03-12
 
 ## Features


### PR DESCRIPTION
Follow-up to #350, which failed on `cargo publish`.

- Fix: Don't use `bootloader_test_runner` dev-dependency in features list

