### PR TITLE
Fix docs.rs build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         run: cargo semver-checks check-release
 
   typos:
-      name: Check spelling
-      runs-on: ubuntu-latest
-      steps:
-        - uses: crate-ci/typos@v1.0.4
+    name: Check spelling
+    runs-on: ubuntu-latest
+    steps:
+      - uses: crate-ci/typos@v1.0.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - name: "Run `cargo check`"
         run: cargo check --all-targets --all
+      - name: "Check docs.rs build"
+        run: cargo check
+        env:
+          RUSTFLAGS: "--cfg docsrs_dummy_build"
 
   test:
     name: Test

--- a/build.rs
+++ b/build.rs
@@ -5,6 +5,11 @@ use std::path::{Path, PathBuf};
 const BOOTLOADER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn main() {
+    #[cfg(not(feature = "uefi"))]
+    async fn uefi_main() {}
+    #[cfg(not(feature = "bios"))]
+    async fn bios_main() {}
+
     block_on((uefi_main(), bios_main()).join());
 }
 


### PR DESCRIPTION
Fixes the current [docs.rs build errors](https://docs.rs/crate/bootloader/0.11.2/builds/764498) by setting the required env variables also for dummy builds.

This issue was introduced in #324. To ensure that we notice such issues in the future, this PR also adds a CI check that verifies that the crate builds with the `docsrs_dummy_build` flag.