### PR TITLE
Update `uefi` dependency to `v0.20`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader"
-version = "0.11.4"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-process",
@@ -173,22 +173,22 @@ dependencies = [
 
 [[package]]
 name = "bootloader-boot-config"
-version = "0.11.4"
+version = "0.11.3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bootloader-x86_64-bios-boot-sector"
-version = "0.11.4"
+version = "0.11.3"
 
 [[package]]
 name = "bootloader-x86_64-bios-common"
-version = "0.11.4"
+version = "0.11.3"
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-2"
-version = "0.11.4"
+version = "0.11.3"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "byteorder",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-3"
-version = "0.11.4"
+version = "0.11.3"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "noto-sans-mono-bitmap 0.1.6",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-4"
-version = "0.11.4"
+version = "0.11.3"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-bios-common",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-common"
-version = "0.11.4"
+version = "0.11.3"
 dependencies = [
  "bootloader-boot-config",
  "bootloader_api",
@@ -239,7 +239,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-uefi"
-version = "0.11.4"
+version = "0.11.3"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-common",
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader_api"
-version = "0.11.4"
+version = "0.11.3"
 dependencies = [
  "rand",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "anyhow",
  "async-process",
@@ -173,22 +173,22 @@ dependencies = [
 
 [[package]]
 name = "bootloader-boot-config"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bootloader-x86_64-bios-boot-sector"
-version = "0.11.3"
+version = "0.11.4"
 
 [[package]]
 name = "bootloader-x86_64-bios-common"
-version = "0.11.3"
+version = "0.11.4"
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-2"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "byteorder",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-3"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "noto-sans-mono-bitmap 0.1.6",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-4"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-bios-common",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-common"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "bootloader-boot-config",
  "bootloader_api",
@@ -239,7 +239,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-uefi"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-common",
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader_api"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "rand",
 ]
@@ -729,6 +729,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcada80daa06c42ed5f48c9a043865edea5dc44cbf9ac009fda3b89526e28607"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca9224df2e20e7c5548aeb5f110a0f3b77ef05f8585139b7148b59056168ed2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1122,21 +1142,22 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b87700863d65dd4841556be3374d8d4f9f8dbb577ad93a39859e70b3b91f35"
+checksum = "ab39d5e7740f21ed4c46d6659f31038bbe3fe7a8be1f702d8a984348837c43b1"
 dependencies = [
  "bitflags",
  "log",
+ "ptr_meta",
  "ucs2",
  "uefi-macros",
 ]
 
 [[package]]
 name = "uefi-macros"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "275f054a1d9fd7e43a2ce91cc24298a87b281117dea8afc120ae95faa0e96b94"
+checksum = "e0caeb0e7b31b9f1f347e541106be10aa8c66c76fa722a3298a4cd21433fabd4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ exclude = ["examples/basic", "examples/test_framework"]
 
 [workspace.package]
 # don't forget to update `workspace.dependencies` below
-version = "0.11.3"
+version = "0.11.4"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-osdev/bootloader"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ exclude = ["examples/basic", "examples/test_framework"]
 
 [workspace.package]
 # don't forget to update `workspace.dependencies` below
-version = "0.11.4"
+version = "0.11.3"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-osdev/bootloader"
 

--- a/tests/runner/src/lib.rs
+++ b/tests/runner/src/lib.rs
@@ -1,6 +1,6 @@
 use bootloader::BootConfig;
 use bootloader::DiskImageBuilder;
-use std::{io::Read, path::Path, process::Command};
+use std::path::Path;
 
 pub fn run_test_kernel(kernel_binary_path: &str) {
     run_test_kernel_internal(kernel_binary_path, None, None)
@@ -92,6 +92,11 @@ fn run_qemu<'a, A>(args: A)
 where
     A: IntoIterator<Item = &'a str>,
 {
+    use std::{
+        io::Read,
+        process::{Command, Stdio},
+    };
+
     const QEMU_ARGS: &[&str] = &[
         "-device",
         "isa-debug-exit,iobase=0xf4,iosize=0x04",
@@ -103,8 +108,6 @@ where
     ];
 
     const SEPARATOR: &str = "\n____________________________________\n";
-
-    use std::process::Stdio;
 
     let mut run_cmd = Command::new("qemu-system-x86_64");
     run_cmd.args(args);

--- a/tests/runner/src/lib.rs
+++ b/tests/runner/src/lib.rs
@@ -2,6 +2,7 @@ use bootloader::BootConfig;
 use bootloader::DiskImageBuilder;
 use std::{io::Read, path::Path, process::Command};
 
+#[allow(dead_code)]
 const QEMU_ARGS: &[&str] = &[
     "-device",
     "isa-debug-exit,iobase=0xf4,iosize=0x04",
@@ -11,6 +12,8 @@ const QEMU_ARGS: &[&str] = &[
     "none",
     "--no-reboot",
 ];
+
+#[allow(dead_code)]
 const SEPARATOR: &str = "\n____________________________________\n";
 
 pub fn run_test_kernel(kernel_binary_path: &str) {
@@ -98,6 +101,7 @@ pub fn run_test_kernel_on_uefi_pxe(out_tftp_path: &Path) {
     run_qemu(args);
 }
 
+#[allow(dead_code)]
 fn run_qemu<'a, A>(args: A)
 where
     A: IntoIterator<Item = &'a str>,

--- a/tests/runner/src/lib.rs
+++ b/tests/runner/src/lib.rs
@@ -87,7 +87,7 @@ pub fn run_test_kernel_on_uefi_pxe(out_tftp_path: &Path) {
     run_qemu(args);
 }
 
-#[allow(dead_code)]
+#[cfg(any(feature = "uefi", feature = "bios"))]
 fn run_qemu<'a, A>(args: A)
 where
     A: IntoIterator<Item = &'a str>,

--- a/tests/runner/src/lib.rs
+++ b/tests/runner/src/lib.rs
@@ -2,20 +2,6 @@ use bootloader::BootConfig;
 use bootloader::DiskImageBuilder;
 use std::{io::Read, path::Path, process::Command};
 
-#[allow(dead_code)]
-const QEMU_ARGS: &[&str] = &[
-    "-device",
-    "isa-debug-exit,iobase=0xf4,iosize=0x04",
-    "-serial",
-    "stdio",
-    "-display",
-    "none",
-    "--no-reboot",
-];
-
-#[allow(dead_code)]
-const SEPARATOR: &str = "\n____________________________________\n";
-
 pub fn run_test_kernel(kernel_binary_path: &str) {
     run_test_kernel_internal(kernel_binary_path, None, None)
 }
@@ -106,6 +92,18 @@ fn run_qemu<'a, A>(args: A)
 where
     A: IntoIterator<Item = &'a str>,
 {
+    const QEMU_ARGS: &[&str] = &[
+        "-device",
+        "isa-debug-exit,iobase=0xf4,iosize=0x04",
+        "-serial",
+        "stdio",
+        "-display",
+        "none",
+        "--no-reboot",
+    ];
+
+    const SEPARATOR: &str = "\n____________________________________\n";
+
     use std::process::Stdio;
 
     let mut run_cmd = Command::new("qemu-system-x86_64");

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -13,6 +13,6 @@ bootloader_api = { workspace = true }
 bootloader-x86_64-common = { workspace = true }
 bootloader-boot-config = { workspace = true }
 log = "0.4.14"
-uefi = "0.18.0"
 x86_64 = "0.14.8"
 serde-json-core = "0.5.0"
+uefi = "0.20.0"

--- a/uefi/src/main.rs
+++ b/uefi/src/main.rs
@@ -136,30 +136,6 @@ fn main_inner(image: Handle, mut st: SystemTable<Boot>) -> Status {
         }
     );
 
-    let _mmap_storage = {
-        let mut memory_map_size = st.boot_services().memory_map_size();
-        loop {
-            let ptr = st
-                .boot_services()
-                .allocate_pool(MemoryType::LOADER_DATA, memory_map_size.map_size)
-                .expect("Failed to allocate memory for mmap storage");
-
-            let storage = unsafe { slice::from_raw_parts_mut(ptr, memory_map_size.map_size) };
-
-            if st.boot_services().memory_map(storage).is_ok() {
-                break storage;
-            }
-
-            // By measuring the size here, we can find out exactly how much we need.
-            // We may hit this code twice, if the map allocation ends up spanning more pages.
-            memory_map_size = st.boot_services().memory_map_size();
-            // allocated memory region was not big enough -> free it again
-            st.boot_services()
-                .free_pool(ptr)
-                .expect("Failed to free temporary memory for memory map!");
-        }
-    };
-
     log::trace!("exiting boot services");
     let (system_table, memory_map) = st.exit_boot_services();
 

--- a/uefi/src/main.rs
+++ b/uefi/src/main.rs
@@ -161,8 +161,7 @@ fn main_inner(image: Handle, mut st: SystemTable<Boot>) -> Status {
     };
 
     log::trace!("exiting boot services");
-    let (system_table, memory_map) = st
-        .exit_boot_services();
+    let (system_table, memory_map) = st.exit_boot_services();
 
     let mut frame_allocator =
         LegacyFrameAllocator::new(memory_map.entries().copied().map(UefiMemoryDescriptor));

--- a/uefi/src/main.rs
+++ b/uefi/src/main.rs
@@ -136,7 +136,7 @@ fn main_inner(image: Handle, mut st: SystemTable<Boot>) -> Status {
         }
     );
 
-    let mmap_storage = {
+    let _mmap_storage = {
         let mut memory_map_size = st.boot_services().memory_map_size();
         loop {
             let ptr = st
@@ -162,11 +162,10 @@ fn main_inner(image: Handle, mut st: SystemTable<Boot>) -> Status {
 
     log::trace!("exiting boot services");
     let (system_table, memory_map) = st
-        .exit_boot_services(image, mmap_storage)
-        .expect("Failed to exit boot services");
+        .exit_boot_services();
 
     let mut frame_allocator =
-        LegacyFrameAllocator::new(memory_map.copied().map(UefiMemoryDescriptor));
+        LegacyFrameAllocator::new(memory_map.entries().copied().map(UefiMemoryDescriptor));
 
     let page_tables = create_page_tables(&mut frame_allocator);
     let mut ramdisk_len = 0u64;


### PR DESCRIPTION
The old version (0.18.0) of the UEFI crate that bootloader 0.11.3 depends on has code that throws a myriad of future incompatibility/deprecation warnings when compilation is attempted ― deprecation warnings that are highlighted in the rust-lang/rust#107457 tracking issue. I therefore created this pull request that both fixes the version of UEFI depended on (0.20 doesn't have the same problems) and bumps the version of bootloader to 0.11.4 to ensure that this fix gets published to crates.io immediately after it's implemented.