### PR TITLE
Use `cargo-semver-checks-action`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,11 +106,16 @@ jobs:
         with:
           shared-key: "semver-checks"
           cache-targets: false
-      - run: cargo install cargo-semver-checks --locked
       - name: Check semver (API)
-        run: cargo semver-checks check-release -p bootloader_api
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          package: bootloader_api
+          prefix-key: api
+          rust-toolchain: manual
       - name: Check semver
-        run: cargo semver-checks check-release
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          rust-toolchain: manual
 
   typos:
     name: Check spelling


### PR DESCRIPTION
Hi! As one of the contributors of cargo-semver-checks I'd want to say we're pleased to see you're using our tool!

Since we've recently released a new, completely rebuilt version of the GitHub action, you can now use it instead of installing cargo-semver-checks manually in CI. One of the key features of the new action is caching the baseline rustdoc between the runs. This will make `Semver Checks` job almost twice as fast on second and each subsequent run (2m 36s vs 4m 8s on my fork).

Setting `rust-toolchain: manual` means the action will use `nightly` as specified in `rust-toolchain.toml` instead of the default `stable`.