### PR TITLE
FrameBuffer API enhancements.

### DIFF
--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -11,21 +11,27 @@ use crate::{concat::*, version_info};
 ///
 /// - Modifying the stack size the bootloader allocates.
 ///
-///  ```no_run
-///  use bootloader_api::{entry_point, BootloaderConfig};
+///   ```no_run
+///   #![no_std]
+///   #![no_main]
 ///
-///  static BOOTLOADER_CONFIG: BootloaderConfig = {
-///      let mut config = BootloaderConfig::new_default();
-///      config.kernel_stack_size = 100 * 1024; // 100 KiB
-///      config
-///  };
+///   static BOOTLOADER_CONFIG: bootloader_api::BootloaderConfig = {
+///       let mut config = bootloader_api::BootloaderConfig::new_default();
+///       config.kernel_stack_size = 100 * 1024; // 100 KiB
+///       config
+///   };
 ///
-///  entry_point!(main, config = &BOOTLOADER_CONFIG);
+///   bootloader_api::entry_point!(main, config = &BOOTLOADER_CONFIG);
 ///
-///  fn main(bootinfo: &'static mut bootloader_api::BootInfo) -> ! {
-///      loop {}
-///  }
-///  ```
+///   fn main(bootinfo: &'static mut bootloader_api::BootInfo) -> ! {
+///       loop {}
+///   }
+///
+///   #[panic_handler]
+///   fn panic(_info: &core::panic::PanicInfo) -> ! {
+///       loop {}
+///   }
+///   ```
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[non_exhaustive]
 pub struct BootloaderConfig {

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -2,10 +2,30 @@
 
 use crate::{concat::*, version_info};
 
-/// Allows configuring the bootloader behavior.
+/// Allows configuring the bootloader's behavior.
 ///
-/// TODO: describe use together with `entry_point` macro
-/// TODO: example
+/// The [`crate::entry_point`] macro provides a second, optional parameter for bootloader configuration.
+/// This parameter takes a value of type `&BootloaderConfig`, defaulting to [`BootloaderConfig::new_default`] if left empty.
+///
+/// ## Examples
+///
+/// - Modifying the stack size the bootloader allocates.
+///
+///  ```no_run
+///  use bootloader_api::{entry_point, BootloaderConfig};
+///
+///  static BOOTLOADER_CONFIG: BootloaderConfig = {
+///      let mut config = BootloaderConfig::new_default();
+///      config.kernel_stack_size = 100 * 1024; // 100 KiB
+///      config
+///  };
+///
+///  entry_point!(main, config = &BOOTLOADER_CONFIG);
+///
+///  fn main(bootinfo: &'static mut bootloader_api::BootInfo) -> ! {
+///      loop {}
+///  }
+///  ```
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[non_exhaustive]
 pub struct BootloaderConfig {

--- a/api/src/info.rs
+++ b/api/src/info.rs
@@ -168,7 +168,7 @@ pub enum MemoryRegionKind {
 }
 
 /// A pixel-based framebuffer that controls the screen output.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct FrameBuffer {
     pub(crate) buffer_start: u64,
@@ -196,7 +196,7 @@ impl FrameBuffer {
         unsafe { self.create_buffer_mut() }
     }
 
-    /// Converts the frame buffer to a raw byte slice.
+    /// Converts the framebuffer to a raw byte slice.
     ///
     /// The same as `buffer_mut()` but takes the ownership and returns the
     /// mutable buffer with a `'static` lifetime.

--- a/api/src/info.rs
+++ b/api/src/info.rs
@@ -186,6 +186,16 @@ impl FrameBuffer {
         Self { buffer_start, info }
     }
 
+    /// Returns the starting address of the framebuffer as a pointer.
+    pub fn buffer_ptr(&self) -> *const u8 {
+        self.buffer_start as *const _
+    }
+
+    /// Returns the starting address of the framebuffer as a mutable pointer.
+    pub fn buffer_mut_ptr(&mut self) -> *mut u8 {
+        self.buffer_start as *mut _
+    }
+
     /// Returns the raw bytes of the framebuffer as a slice.
     pub fn buffer(&self) -> &[u8] {
         unsafe { self.create_buffer() }

--- a/api/src/info.rs
+++ b/api/src/info.rs
@@ -186,19 +186,14 @@ impl FrameBuffer {
         Self { buffer_start, info }
     }
 
-    /// Returns the starting address of the framebuffer as a pointer.
-    pub fn buffer_ptr(&self) -> *const u8 {
-        self.buffer_start as *const _
-    }
-
-    /// Returns the starting address of the framebuffer as a mutable pointer.
-    pub fn buffer_mut_ptr(&mut self) -> *mut u8 {
-        self.buffer_start as *mut _
+    /// Returns the starting address of the framebuffer, represented as an integer.
+    pub fn buffer_start(&self) -> u64 {
+        self.buffer_start
     }
 
     /// Returns the raw bytes of the framebuffer as a slice.
     pub fn buffer(&self) -> &[u8] {
-        unsafe { self.create_buffer() }
+        unsafe { slice::from_raw_parts(self.buffer_start as *const u8, self.info.byte_len) }
     }
 
     /// Returns the raw bytes of the framebuffer as a mutable slice.
@@ -214,17 +209,14 @@ impl FrameBuffer {
         unsafe { self.create_buffer_mut() }
     }
 
-    unsafe fn create_buffer<'a>(&self) -> &'a [u8] {
-        unsafe { slice::from_raw_parts(self.buffer_start as *const u8, self.info.byte_len) }
-    }
-
-    unsafe fn create_buffer_mut<'a>(&self) -> &'a mut [u8] {
-        unsafe { slice::from_raw_parts_mut(self.buffer_start as *mut u8, self.info.byte_len) }
-    }
-
     /// Returns the layout and pixel format information of the framebuffer.
     pub fn info(&self) -> FrameBufferInfo {
         self.info
+    }
+
+    #[inline]
+    unsafe fn create_buffer_mut<'a>(&self) -> &'a mut [u8] {
+        unsafe { slice::from_raw_parts_mut(self.buffer_start as *mut u8, self.info.byte_len) }
     }
 }
 

--- a/api/src/info.rs
+++ b/api/src/info.rs
@@ -171,8 +171,8 @@ pub enum MemoryRegionKind {
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct FrameBuffer {
-    pub(crate) buffer_start: u64,
-    pub(crate) info: FrameBufferInfo,
+    buffer_start: u64,
+    info: FrameBufferInfo,
 }
 
 impl FrameBuffer {

--- a/api/src/info.rs
+++ b/api/src/info.rs
@@ -186,12 +186,12 @@ impl FrameBuffer {
         Self { buffer_start, info }
     }
 
-    /// Returns the raw bytes of the framebuffer as slice.
+    /// Returns the raw bytes of the framebuffer as a slice.
     pub fn buffer(&self) -> &[u8] {
         unsafe { self.create_buffer() }
     }
 
-    /// Returns the raw bytes of the framebuffer as mutable slice.
+    /// Returns the raw bytes of the framebuffer as a mutable slice.
     pub fn buffer_mut(&mut self) -> &mut [u8] {
         unsafe { self.create_buffer_mut() }
     }
@@ -212,7 +212,7 @@ impl FrameBuffer {
         unsafe { slice::from_raw_parts_mut(self.buffer_start as *mut u8, self.info.byte_len) }
     }
 
-    /// Returns layout and pixel format information of the framebuffer.
+    /// Returns the layout and pixel format information of the framebuffer.
     pub fn info(&self) -> FrameBufferInfo {
         self.info
     }


### PR DESCRIPTION
This PR serves to provide the following changes:
- The `FrameBuffer` type now implements `Clone` and `Copy` so the `into_buffer` function can work when using a `FrameBuffer` given by `BootInfo`.
- The `buffer_start` field is exposed via a new function of the same name. This is to provide a shortcut for manually retrieving the buffer's start address like: `frame_buffer.buffer() as *const _ as u64`.
- Documentation is very minimally improved. There's more consistency within the writing, as well as a link that was otherwise missing.
- The unnecessary internal `create_buffer` function is removed. `create_buffer_mut` is additionally marked as `inline`.
- The visibility on `FrameBuffer`'s fields is reduced from `pub(crate)` to private, seeing as nothing in the library actually directly used the fields.