### PR TITLE
Release `v0.11.4`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "anyhow",
  "async-process",
@@ -180,22 +180,22 @@ dependencies = [
 
 [[package]]
 name = "bootloader-boot-config"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bootloader-x86_64-bios-boot-sector"
-version = "0.11.3"
+version = "0.11.4"
 
 [[package]]
 name = "bootloader-x86_64-bios-common"
-version = "0.11.3"
+version = "0.11.4"
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-2"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "byteorder",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-3"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "noto-sans-mono-bitmap 0.1.6",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-4"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-bios-common",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-common"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "bootloader-boot-config",
  "bootloader_api",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-uefi"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-common",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader_api"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "rand",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,15 +31,15 @@ exclude = ["examples/basic", "examples/test_framework"]
 
 [workspace.package]
 # don't forget to update `workspace.dependencies` below
-version = "0.11.3"
+version = "0.11.4"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-osdev/bootloader"
 
 [workspace.dependencies]
-bootloader_api = { version = "0.11.3", path = "api" }
-bootloader-x86_64-common = { version = "0.11.3", path = "common" }
-bootloader-boot-config = { version = "0.11.3", path = "common/config" }
-bootloader-x86_64-bios-common = { version = "0.11.3", path = "bios/common" }
+bootloader_api = { version = "0.11.4", path = "api" }
+bootloader-x86_64-common = { version = "0.11.4", path = "common" }
+bootloader-boot-config = { version = "0.11.4", path = "common/config" }
+bootloader-x86_64-bios-common = { version = "0.11.4", path = "bios/common" }
 
 [features]
 default = ["bios", "uefi"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+- [Fix bug stemming from treating an exclusive range as an inclusive ranges](https://github.com/rust-osdev/bootloader/pull/362)
+- [Update `uefi` dependency to `v0.20`](https://github.com/rust-osdev/bootloader/pull/360)
+- [Implemented sorting of uefi memory maps](https://github.com/rust-osdev/bootloader/pull/365)
+- [Run `cargo update` to fix build on nightly](https://github.com/rust-osdev/bootloader/pull/385)
+
 # 0.11.3 – 2023-03-26
 
 - [Fix docs.rs build](https://github.com/rust-osdev/bootloader/pull/358)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.11.4 – 2023-07-05
+
 - [Fix bug stemming from treating an exclusive range as an inclusive ranges](https://github.com/rust-osdev/bootloader/pull/362)
 - [Update `uefi` dependency to `v0.20`](https://github.com/rust-osdev/bootloader/pull/360)
 - [Implemented sorting of uefi memory maps](https://github.com/rust-osdev/bootloader/pull/365)


### PR DESCRIPTION
## What's Changed
* Fixed bug stemming from treating an exclusive range as an inclusive r… by @JarlEvanson in https://github.com/rust-osdev/bootloader/pull/362
* Update `uefi` dependency to `v0.20` by @kennystrawnmusic in https://github.com/rust-osdev/bootloader/pull/360
* Implemented sorting of uefi memory maps #315 by @JarlEvanson in https://github.com/rust-osdev/bootloader/pull/365
* Use `cargo-semver-checks-action` by @mgr0dzicki in https://github.com/rust-osdev/bootloader/pull/369
* Run `cargo update` to fix build on nightly by @phil-opp in https://github.com/rust-osdev/bootloader/pull/385

## New Contributors
* @JarlEvanson made their first contribution in https://github.com/rust-osdev/bootloader/pull/362
* @mgr0dzicki made their first contribution in https://github.com/rust-osdev/bootloader/pull/369

**Full Changelog**: https://github.com/rust-osdev/bootloader/compare/v0.11.3...v0.11.4