### PR TITLE
RacyCell<T>: Data race allowed on T

### DIFF
--- a/bios/common/src/racy_cell.rs
+++ b/bios/common/src/racy_cell.rs
@@ -18,4 +18,4 @@ impl<T> RacyCell<T> {
 }
 
 unsafe impl<T> Send for RacyCell<T> where T: Send {}
-unsafe impl<T> Sync for RacyCell<T> {}
+unsafe impl<T: Sync> Sync for RacyCell<T> {}


### PR DESCRIPTION
Hi,
I found a memory-safety/soundness issue in this crate while scanning Rust code for potential vulnerabilities. This PR contains a fix for the issue.

# Issue Description
`RacyCell<T>` unconditionally implements Sync. This allows users to create data races on `T: !Sync`. Such data races can lead to undefined behavior.

https://github.com/rust-osdev/bootloader/blob/c5e5ed2cb38e4779c5a6ca67b07719a4bfdb1298/bios/common/src/racy_cell.rs#L21