### PR TITLE
Add support for the UEFI runtime table address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ dependencies = [
  "bootloader_api",
  "log",
  "serde-json-core",
- "uefi",
+ "uefi 0.20.0",
  "x86_64",
 ]
 
@@ -262,6 +262,7 @@ name = "bootloader_api"
 version = "0.11.4"
 dependencies = [
  "rand",
+ "uefi 0.24.0",
 ]
 
 [[package]]
@@ -1173,7 +1174,22 @@ dependencies = [
  "log",
  "ptr_meta",
  "ucs2",
- "uefi-macros",
+ "uefi-macros 0.11.0",
+]
+
+[[package]]
+name = "uefi"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b63e82686b4bdb0db74f18b2abbd60a0470354fb640aa69e115598d714d0a10"
+dependencies = [
+ "bitflags 2.3.3",
+ "log",
+ "ptr_meta",
+ "ucs2",
+ "uefi-macros 0.12.0",
+ "uefi-raw",
+ "uguid",
 ]
 
 [[package]]
@@ -1186,6 +1202,34 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "uefi-macros"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023d94ef8e135d068b9a3bd94614ef2610b2b0419ade0a9d8f3501fa9cd08e95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+]
+
+[[package]]
+name = "uefi-raw"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62642516099c6441a5f41b0da8486d5fc3515a0603b0fdaea67b31600e22082e"
+dependencies = [
+ "bitflags 2.3.3",
+ "ptr_meta",
+ "uguid",
+]
+
+[[package]]
+name = "uguid"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16dfbd255defbd727b3a30e8950695d2e6d045841ee250ff0f1f7ced17917f8d"
 
 [[package]]
 name = "unicode-ident"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -9,6 +9,7 @@ description = "Makes a kernel compatible with the bootloader crate"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+uefi = "0.24.0"
 
 [dev-dependencies]
 rand = "0.8.4"

--- a/api/src/info.rs
+++ b/api/src/info.rs
@@ -63,6 +63,9 @@ pub struct BootInfo {
     /// Virtual address of the loaded kernel image.
     pub kernel_image_offset: u64,
 
+    /// UEFI runtime table address (if running on UEFI)
+    pub rt_table_addr: Optional<u64>,
+
     #[doc(hidden)]
     pub _test_sentinel: u64,
 }
@@ -85,6 +88,7 @@ impl BootInfo {
             kernel_addr: 0,
             kernel_len: 0,
             kernel_image_offset: 0,
+            rt_table_addr: Optional::None,
             _test_sentinel: 0,
         }
     }

--- a/bios/stage-4/src/main.rs
+++ b/bios/stage-4/src/main.rs
@@ -164,6 +164,7 @@ pub extern "C" fn _start(info: &mut BiosInfo) -> ! {
             _ => Some(info.ramdisk.start),
         },
         ramdisk_len: info.ramdisk.len,
+        rt_table_addr: None,
     };
 
     load_and_switch_to_kernel(kernel, config, frame_allocator, page_tables, system_info);

--- a/uefi/src/main.rs
+++ b/uefi/src/main.rs
@@ -166,6 +166,7 @@ fn main_inner(image: Handle, mut st: SystemTable<Boot>) -> Status {
         },
         ramdisk_addr,
         ramdisk_len,
+        rt_table_addr: Some(system_table.get_current_system_table_addr()),
     };
 
     bootloader_x86_64_common::load_and_switch_to_kernel(


### PR DESCRIPTION
Although not always needed, UEFI runtime services are still important for some use cases, most notable knowing what time it is — something that needs to be constantly queried, so hardcoding the time into `BootInfo` won't help much. Thankfully, the UEFI crate has a method on `SystemTable<Runtime>` for retrieving the memory address of the runtime services table, which a kernel can then access via a raw pointer. As such, I've chosen to contribute this as an option for ensuring that kernels can do exactly that.