### PR TITLE
Embed bios and uefi binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ bootloader-x86_64-bios-common = { version = "0.11.4", path = "bios/common" }
 default = ["bios", "uefi"]
 bios = ["dep:mbrman"]
 uefi = ["dep:gpt"]
+embedded_binaries = []
 
 [dependencies]
 anyhow = "1.0.32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ bootloader-x86_64-bios-common = { version = "0.11.4", path = "bios/common" }
 default = ["bios", "uefi"]
 bios = ["dep:mbrman"]
 uefi = ["dep:gpt"]
-embedded_binaries = []
 
 [dependencies]
 anyhow = "1.0.32"

--- a/build.rs
+++ b/build.rs
@@ -21,7 +21,6 @@ async fn bios_main() {
     // BIOS crates don't have enough dependencies to utilize all cores on modern
     // CPUs. So by running the build commands in parallel, we increase the number
     // of utilized cores.)
-    #[cfg(not(docsrs_dummy_build))]
     let (bios_boot_sector_path, bios_stage_2_path, bios_stage_3_path, bios_stage_4_path) = (
         build_bios_boot_sector(&out_dir),
         build_bios_stage_2(&out_dir),
@@ -30,14 +29,6 @@ async fn bios_main() {
     )
         .join()
         .await;
-    // dummy implementations because docsrs builds have no network access
-    #[cfg(docsrs_dummy_build)]
-    let (bios_boot_sector_path, bios_stage_2_path, bios_stage_3_path, bios_stage_4_path) = (
-        PathBuf::new(),
-        PathBuf::new(),
-        PathBuf::new(),
-        PathBuf::new(),
-    );
     println!(
         "cargo:rustc-env=BIOS_BOOT_SECTOR_PATH={}",
         bios_boot_sector_path.display()
@@ -60,11 +51,7 @@ async fn bios_main() {
 async fn uefi_main() {
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
 
-    #[cfg(not(docsrs_dummy_build))]
     let uefi_path = build_uefi_bootloader(&out_dir).await;
-    // dummy implementation because docsrs builds have no network access
-    #[cfg(docsrs_dummy_build)]
-    let uefi_path = PathBuf::new();
 
     println!(
         "cargo:rustc-env=UEFI_BOOTLOADER_PATH={}",
@@ -109,6 +96,26 @@ async fn build_uefi_bootloader(out_dir: &Path) -> PathBuf {
     }
 }
 
+// dummy implementation because docsrs builds have no network access.
+// This will put an empty file in out_dir and return its path.
+#[cfg(docsrs_dummy_build)]
+#[cfg(feature = "uefi")]
+async fn build_uefi_bootloader(out_dir: &Path) -> PathBuf {
+    use std::fs::File;
+
+    let path = out_dir.join("bootloader-dummy-bootloader-uefi");
+
+    if File::create(&path).is_err() {
+        panic!("Failed to create dummy uefi bootloader");
+    }
+    assert!(
+        path.exists(),
+        "uefi bootloader dummy file does not exist after file creation"
+    );
+
+    path
+}
+
 #[cfg(not(docsrs_dummy_build))]
 #[cfg(feature = "bios")]
 async fn build_bios_boot_sector(out_dir: &Path) -> PathBuf {
@@ -151,6 +158,26 @@ async fn build_bios_boot_sector(out_dir: &Path) -> PathBuf {
         panic!("failed to build bios boot sector");
     };
     convert_elf_to_bin(elf_path).await
+}
+
+// dummy implementation because docsrs builds have no network access.
+// This will put an empty file in out_dir and return its path.
+#[cfg(docsrs_dummy_build)]
+#[cfg(feature = "bios")]
+async fn build_bios_boot_sector(out_dir: &Path) -> PathBuf {
+    use std::fs::File;
+
+    let path = out_dir.join("bootloader-dummy-bios-boot-sector");
+
+    if File::create(&path).is_err() {
+        panic!("Failed to create dummy bios boot sector");
+    }
+    assert!(
+        path.exists(),
+        "bios boot sector dummy file does not exist after file creation"
+    );
+
+    path
 }
 
 #[cfg(not(docsrs_dummy_build))]
@@ -199,6 +226,26 @@ async fn build_bios_stage_2(out_dir: &Path) -> PathBuf {
     convert_elf_to_bin(elf_path).await
 }
 
+// dummy implementation because docsrs builds have no network access.
+// This will put an empty file in out_dir and return its path.
+#[cfg(docsrs_dummy_build)]
+#[cfg(feature = "bios")]
+async fn build_bios_stage_2(out_dir: &Path) -> PathBuf {
+    use std::fs::File;
+
+    let path = out_dir.join("bootloader-dummy-bios-stage-2");
+
+    if File::create(&path).is_err() {
+        panic!("Failed to create dummy bios second stage");
+    }
+    assert!(
+        path.exists(),
+        "bios second stage dummy file does not exist after file creation"
+    );
+
+    path
+}
+
 #[cfg(not(docsrs_dummy_build))]
 #[cfg(feature = "bios")]
 async fn build_bios_stage_3(out_dir: &Path) -> PathBuf {
@@ -239,6 +286,26 @@ async fn build_bios_stage_3(out_dir: &Path) -> PathBuf {
         panic!("failed to build bios stage-3");
     };
     convert_elf_to_bin(elf_path).await
+}
+
+// dummy implementation because docsrs builds have no network access.
+// This will put an empty file in out_dir and return its path.
+#[cfg(docsrs_dummy_build)]
+#[cfg(feature = "bios")]
+async fn build_bios_stage_3(out_dir: &Path) -> PathBuf {
+    use std::fs::File;
+
+    let path = out_dir.join("bootloader-dummy-bios-stage-3");
+
+    if File::create(&path).is_err() {
+        panic!("Failed to create dummy bios stage-3");
+    }
+    assert!(
+        path.exists(),
+        "bios stage-3 dummy file does not exist after file creation"
+    );
+
+    path
 }
 
 #[cfg(not(docsrs_dummy_build))]
@@ -282,6 +349,26 @@ async fn build_bios_stage_4(out_dir: &Path) -> PathBuf {
     };
 
     convert_elf_to_bin(elf_path).await
+}
+
+// dummy implementation because docsrs builds have no network access.
+// This will put an empty file in out_dir and return its path.
+#[cfg(docsrs_dummy_build)]
+#[cfg(feature = "bios")]
+async fn build_bios_stage_4(out_dir: &Path) -> PathBuf {
+    use std::fs::File;
+
+    let path = out_dir.join("bootloader-dummy-bios-stage-4");
+
+    if File::create(&path).is_err() {
+        panic!("Failed to create dummy bios stage-4");
+    }
+    assert!(
+        path.exists(),
+        "bios stage-4 dummy file does not exist after file creation"
+    );
+
+    path
 }
 
 #[cfg(not(docsrs_dummy_build))]

--- a/src/file_data_source.rs
+++ b/src/file_data_source.rs
@@ -59,7 +59,7 @@ impl FileDataSource {
             FileDataSource::Bytes(contents) => {
                 let mut cursor = Cursor::new(contents);
                 io::copy(&mut cursor, target)?;
-            },
+            }
         };
 
         Ok(())

--- a/src/file_data_source.rs
+++ b/src/file_data_source.rs
@@ -11,6 +11,7 @@ use std::{fs, io};
 pub enum FileDataSource {
     File(PathBuf),
     Data(Vec<u8>),
+    Bytes(&'static [u8]),
 }
 
 impl Debug for FileDataSource {
@@ -21,6 +22,9 @@ impl Debug for FileDataSource {
             }
             FileDataSource::Data(d) => {
                 f.write_fmt(format_args!("data source: {} raw bytes ", d.len()))
+            }
+            FileDataSource::Bytes(b) => {
+                f.write_fmt(format_args!("data source: {} raw bytes ", b.len()))
             }
         }
     }
@@ -34,6 +38,7 @@ impl FileDataSource {
                 .with_context(|| format!("failed to read metadata of file `{}`", path.display()))?
                 .len(),
             FileDataSource::Data(v) => v.len() as u64,
+            FileDataSource::Bytes(s) => s.len() as u64,
         })
     }
     /// Copy this data source to the specified target that implements io::Write
@@ -51,6 +56,10 @@ impl FileDataSource {
                 let mut cursor = Cursor::new(contents);
                 io::copy(&mut cursor, target)?;
             }
+            FileDataSource::Bytes(contents) => {
+                let mut cursor = Cursor::new(contents);
+                io::copy(&mut cursor, target)?;
+            },
         };
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,14 +151,8 @@ impl DiskImageBuilder {
         let stage_3 = FileDataSource::Data(BIOS_STAGE_3.to_vec());
         let stage_4 = FileDataSource::Data(BIOS_STAGE_4.to_vec());
         let mut internal_files = BTreeMap::new();
-        internal_files.insert(
-            BIOS_STAGE_3_NAME,
-            stage_3,
-        );
-        internal_files.insert(
-            BIOS_STAGE_4_NAME,
-            stage_4,
-        );
+        internal_files.insert(BIOS_STAGE_3_NAME, stage_3);
+        internal_files.insert(BIOS_STAGE_4_NAME, stage_4);
         let fat_partition = self
             .create_fat_filesystem_image(internal_files)
             .context("failed to create FAT partition")?;
@@ -192,10 +186,7 @@ impl DiskImageBuilder {
         }
 
         let mut internal_files = BTreeMap::new();
-        internal_files.insert(
-            UEFI_BOOT_FILENAME,
-            get_uefi_bootloader(),
-        );
+        internal_files.insert(UEFI_BOOT_FILENAME, get_uefi_bootloader());
         let fat_partition = self
             .create_fat_filesystem_image(internal_files)
             .context("failed to create FAT partition")?;
@@ -240,7 +231,6 @@ impl DiskImageBuilder {
 
         let to = tftp_path.join(UEFI_TFTP_BOOT_FILENAME);
         write_uefi_bootloader(&to)?;
-        
 
         for f in &self.files {
             let to = tftp_path.join(f.0.deref());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,10 +41,15 @@ const KERNEL_FILE_NAME: &str = "kernel-x86_64";
 const RAMDISK_FILE_NAME: &str = "ramdisk";
 const CONFIG_FILE_NAME: &str = "boot.json";
 
+#[cfg(feature = "uefi")]
 const UEFI_BOOTLOADER: &[u8] = include_bytes!(env!("UEFI_BOOTLOADER_PATH"));
+#[cfg(feature = "bios")]
 const BIOS_BOOT_SECTOR: &[u8] = include_bytes!(env!("BIOS_BOOT_SECTOR_PATH"));
+#[cfg(feature = "bios")]
 const BIOS_STAGE_2: &[u8] = include_bytes!(env!("BIOS_STAGE_2_PATH"));
+#[cfg(feature = "bios")]
 const BIOS_STAGE_3: &[u8] = include_bytes!(env!("BIOS_STAGE_3_PATH"));
+#[cfg(feature = "bios")]
 const BIOS_STAGE_4: &[u8] = include_bytes!(env!("BIOS_STAGE_4_PATH"));
 
 /// Allows creating disk images for a specified set of files.
@@ -101,6 +106,7 @@ impl DiskImageBuilder {
         self.set_file_source(destination.into(), FileDataSource::File(file_path))
     }
 
+    #[cfg(feature = "bios")]
     /// Create an MBR disk image for booting on BIOS systems.
     pub fn create_bios_image(&self, image_path: &Path) -> anyhow::Result<()> {
         const BIOS_STAGE_3_NAME: &str = "boot-stage-3";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,7 +216,7 @@ impl DiskImageBuilder {
         #[cfg(not(feature = "embedded_binaries"))]
         fn write_uefi_bootloader(to: &PathBuf) -> anyhow::Result<()> {
             let bootloader_path = Path::new(env!("UEFI_BOOTLOADER_PATH"));
-            fs::copy(bootloader_path, &to).map(|_| ()).with_context(|| {
+            fs::copy(bootloader_path, to).map(|_| ()).with_context(|| {
                 format!(
                     "failed to copy bootloader from {} to {}",
                     bootloader_path.display(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,11 +41,11 @@ const KERNEL_FILE_NAME: &str = "kernel-x86_64";
 const RAMDISK_FILE_NAME: &str = "ramdisk";
 const CONFIG_FILE_NAME: &str = "boot.json";
 
-static UEFI_BOOTLOADER: &'static [u8] = include_bytes!(env!("UEFI_BOOTLOADER_PATH"));
-static BIOS_BOOT_SECTOR: &'static [u8] = include_bytes!(env!("BIOS_BOOT_SECTOR_PATH"));
-static BIOS_STAGE_2: &'static [u8] = include_bytes!(env!("BIOS_STAGE_2_PATH"));
-static BIOS_STAGE_3: &'static [u8] = include_bytes!(env!("BIOS_STAGE_3_PATH"));
-static BIOS_STAGE_4: &'static [u8] = include_bytes!(env!("BIOS_STAGE_4_PATH"));
+const UEFI_BOOTLOADER: &[u8] = include_bytes!(env!("UEFI_BOOTLOADER_PATH"));
+const BIOS_BOOT_SECTOR: &[u8] = include_bytes!(env!("BIOS_BOOT_SECTOR_PATH"));
+const BIOS_STAGE_2: &[u8] = include_bytes!(env!("BIOS_STAGE_2_PATH"));
+const BIOS_STAGE_3: &[u8] = include_bytes!(env!("BIOS_STAGE_3_PATH"));
+const BIOS_STAGE_4: &[u8] = include_bytes!(env!("BIOS_STAGE_4_PATH"));
 
 /// Allows creating disk images for a specified set of files.
 ///

--- a/src/mbr.rs
+++ b/src/mbr.rs
@@ -15,17 +15,19 @@ pub fn create_mbr_disk(
     boot_partition_path: &Path,
     out_mbr_path: &Path,
 ) -> anyhow::Result<()> {
-    let second_stage = File::open(second_stage_path).context("failed to open second stage binary")?;
+    let second_stage =
+        File::open(second_stage_path).context("failed to open second stage binary")?;
     create_mbr_disk_with_readers(
         File::open(bootsector_path).context("failed to open boot sector")?,
         SecondStageData {
-            size: second_stage.metadata()
-            .context("failed to read file metadata of second stage")?
-            .len(),
-            reader: second_stage
+            size: second_stage
+                .metadata()
+                .context("failed to read file metadata of second stage")?
+                .len(),
+            reader: second_stage,
         },
         boot_partition_path,
-        out_mbr_path
+        out_mbr_path,
     )
 }
 
@@ -44,7 +46,7 @@ pub fn create_mbr_disk(
             reader: Cursor::new(second_stage_binary),
         },
         boot_partition_path,
-        out_mbr_path
+        out_mbr_path,
     )
 }
 

--- a/src/mbr.rs
+++ b/src/mbr.rs
@@ -2,18 +2,65 @@ use anyhow::Context;
 use mbrman::BOOT_ACTIVE;
 use std::{
     fs::{self, File},
-    io::{self, Seek, SeekFrom},
+    io::{self, Read, Seek, SeekFrom},
     path::Path,
 };
+
 const SECTOR_SIZE: u32 = 512;
 
+#[cfg(not(feature = "embedded_binaries"))]
 pub fn create_mbr_disk(
     bootsector_path: &Path,
     second_stage_path: &Path,
     boot_partition_path: &Path,
     out_mbr_path: &Path,
 ) -> anyhow::Result<()> {
-    let mut boot_sector = File::open(bootsector_path).context("failed to open boot sector")?;
+    let second_stage = File::open(second_stage_path).context("failed to open second stage binary")?;
+    create_mbr_disk_with_readers(
+        File::open(bootsector_path).context("failed to open boot sector")?,
+        SecondStageData {
+            size: second_stage.metadata()
+            .context("failed to read file metadata of second stage")?
+            .len(),
+            reader: second_stage
+        },
+        boot_partition_path,
+        out_mbr_path
+    )
+}
+
+#[cfg(feature = "embedded_binaries")]
+pub fn create_mbr_disk(
+    bootsector_binary: &[u8],
+    second_stage_binary: &[u8],
+    boot_partition_path: &Path,
+    out_mbr_path: &Path,
+) -> anyhow::Result<()> {
+    use std::io::Cursor;
+    create_mbr_disk_with_readers(
+        Cursor::new(bootsector_binary),
+        SecondStageData {
+            size: second_stage_binary.len() as u64,
+            reader: Cursor::new(second_stage_binary),
+        },
+        boot_partition_path,
+        out_mbr_path
+    )
+}
+
+struct SecondStageData<R> {
+    size: u64,
+    reader: R,
+}
+
+fn create_mbr_disk_with_readers<R: Read + Seek>(
+    bootsector_reader: R,
+    second_stage_data: SecondStageData<R>,
+    boot_partition_path: &Path,
+    out_mbr_path: &Path,
+) -> anyhow::Result<()> {
+    // let mut boot_sector = File::open(bootsector_path).context("failed to open boot sector")?;
+    let mut boot_sector = bootsector_reader;
     let mut mbr =
         mbrman::MBR::read_from(&mut boot_sector, SECTOR_SIZE).context("failed to read MBR")?;
 
@@ -23,12 +70,9 @@ pub fn create_mbr_disk(
         }
     }
 
-    let mut second_stage =
-        File::open(second_stage_path).context("failed to open second stage binary")?;
-    let second_stage_size = second_stage
-        .metadata()
-        .context("failed to read file metadata of second stage")?
-        .len();
+    let mut second_stage = second_stage_data.reader;
+    let second_stage_size = second_stage_data.size;
+
     let second_stage_start_sector = 1;
     let second_stage_sectors = ((second_stage_size - 1) / u64::from(SECTOR_SIZE) + 1)
         .try_into()


### PR DESCRIPTION
This crate embeds links to bios and uefi binaries created in the build.rs script, and that means you can't depend on it with a crate from crates.io, as the binaries created are deleted after the final binary (with the code that you actually wrote) is moved to .cargo/bin/ and it throws a file not found error.
This was kind of annoying to pin down, because when I manually built it, it worked, until it stopped randomly. This was caused (although I didn't know this at the time) by the files being cleaned from the directory they were built in, no matter where the final binary was at that point.

So here is my solution; feature-gated binary embedding using include_bytes!()
I had to rewrite part of mbr but the api is exactly the same when the feature is disabled.

The main reason I wanted to use it as a dependency was to make a command-line interface to replace bootimage, which doesn't work with 10.x or 11.x (the resulting command-line crate is [here](https://crates.io/crates/bootloader_linker)) and I liked the crate structure that bootimage encouraged (main.rs, entry_point!(), lib.rs etc.) as opposed to the crate structure currently recommended (a build.rs that links bootloader to a subpackage containing the kernel and a main.rs that calls qemu).

Anyway, if this is all a terrible idea, please let me know.