### PR TITLE
Add an additional MB of space to the generated FAT partition

### DIFF
--- a/src/fat.rs
+++ b/src/fat.rs
@@ -26,7 +26,7 @@ pub fn create_fat_filesystem(
         .truncate(true)
         .open(out_fat_path)
         .unwrap();
-    let fat_size_padded_and_rounded = ((needed_size + 1024 * 64 - 1) / MB + 1) * MB;
+    let fat_size_padded_and_rounded = ((needed_size + 1024 * 64 - 1) / MB + 1) * MB + MB;
     fat_file.set_len(fat_size_padded_and_rounded).unwrap();
 
     // choose a file system label


### PR DESCRIPTION
Increasing the image size by an additional megabyte makes the image compile again

Fixes #396 