### PR TITLE
Fix: Enable test runner again

### DIFF
--- a/tests/runner/Cargo.toml
+++ b/tests/runner/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+default = ["bios", "uefi"]
 bios = ["bootloader/bios"]
 uefi = ["bootloader/uefi", "dep:ovmf-prebuilt"]
 


### PR DESCRIPTION
The test runner was accidentally disabled in #351, in an attempt to fix the publish errors introduced by #304 (caused by a bug in cargo: https://github.com/rust-lang/cargo/issues/12225). As a result, the test runner became a no-op as neither the bios nor the uefi features were enabled.

This commit fixes the issue by enabling both features by default. Once the cargo bug is fixed, we might want to switch back to the feature configuration added of #304.

Fixes #405
