### PR TITLE
Release `v0.11.5`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "async-process",
@@ -180,22 +180,22 @@ dependencies = [
 
 [[package]]
 name = "bootloader-boot-config"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bootloader-x86_64-bios-boot-sector"
-version = "0.11.4"
+version = "0.11.5"
 
 [[package]]
 name = "bootloader-x86_64-bios-common"
-version = "0.11.4"
+version = "0.11.5"
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-2"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "byteorder",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-3"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "noto-sans-mono-bitmap 0.1.6",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-4"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-bios-common",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-common"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "bootloader-boot-config",
  "bootloader_api",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-uefi"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-common",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader_api"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "rand",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,15 +31,15 @@ exclude = ["examples/basic", "examples/test_framework"]
 
 [workspace.package]
 # don't forget to update `workspace.dependencies` below
-version = "0.11.4"
+version = "0.11.5"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-osdev/bootloader"
 
 [workspace.dependencies]
-bootloader_api = { version = "0.11.4", path = "api" }
-bootloader-x86_64-common = { version = "0.11.4", path = "common" }
-bootloader-boot-config = { version = "0.11.4", path = "common/config" }
-bootloader-x86_64-bios-common = { version = "0.11.4", path = "bios/common" }
+bootloader_api = { version = "0.11.5", path = "api" }
+bootloader-x86_64-common = { version = "0.11.5", path = "common" }
+bootloader-boot-config = { version = "0.11.5", path = "common/config" }
+bootloader-x86_64-bios-common = { version = "0.11.5", path = "bios/common" }
 
 [features]
 default = ["bios", "uefi"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,17 @@
 # Unreleased
 
+# 0.11.5 – 2023-12-28
+
+* [RacyCell<T>: Data race allowed on `T`](https://github.com/rust-osdev/bootloader/pull/390)
+* [Update license field following SPDX 2.1 license expression standard](https://github.com/rust-osdev/bootloader/pull/391)
+* [kernel image fields & zero out rbp](https://github.com/rust-osdev/bootloader/pull/346)
+* [Update `rustix` dependency](https://github.com/rust-osdev/bootloader/pull/398)
+* [Add an additional MB of space to the generated FAT partition](https://github.com/rust-osdev/bootloader/pull/397)
+* [Fix: Enable test runner again](https://github.com/rust-osdev/bootloader/pull/407)
+* [Fix: Mark `ramdisk` as used in memory map](https://github.com/rust-osdev/bootloader/pull/408)
+
+**Full Changelog**: https://github.com/rust-osdev/bootloader/compare/v0.11.4...v0.11.5
+
 # 0.11.4 – 2023-07-05
 
 - [Fix bug stemming from treating an exclusive range as an inclusive ranges](https://github.com/rust-osdev/bootloader/pull/362)


### PR DESCRIPTION
## What's Changed
* RacyCell<T>: Data race allowed on T by @kuzeyardabulut in https://github.com/rust-osdev/bootloader/pull/390
* Update license field following SPDX 2.1 license expression standard by @frisoft in https://github.com/rust-osdev/bootloader/pull/391
* kernel image fields & zero out rbp by @devsnek in https://github.com/rust-osdev/bootloader/pull/346
* Update `rustix` dependency by @phil-opp in https://github.com/rust-osdev/bootloader/pull/398
* Add an additional MB of space to the generated FAT partition by @kennystrawnmusic in https://github.com/rust-osdev/bootloader/pull/397
* Fix: Enable test runner again by @phil-opp in https://github.com/rust-osdev/bootloader/pull/407
* Fix: Mark `ramdisk` as used in memory map by @phil-opp in https://github.com/rust-osdev/bootloader/pull/408

## New Contributors
* @kuzeyardabulut made their first contribution in https://github.com/rust-osdev/bootloader/pull/390
* @frisoft made their first contribution in https://github.com/rust-osdev/bootloader/pull/391
* @devsnek made their first contribution in https://github.com/rust-osdev/bootloader/pull/346

**Full Changelog**: https://github.com/rust-osdev/bootloader/compare/v0.11.4...v0.11.5