### PR TITLE
Release `v0.11.6`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "anyhow",
  "async-process",
@@ -180,22 +180,22 @@ dependencies = [
 
 [[package]]
 name = "bootloader-boot-config"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bootloader-x86_64-bios-boot-sector"
-version = "0.11.5"
+version = "0.11.6"
 
 [[package]]
 name = "bootloader-x86_64-bios-common"
-version = "0.11.5"
+version = "0.11.6"
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-2"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "byteorder",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-3"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "noto-sans-mono-bitmap 0.1.6",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-4"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-bios-common",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-common"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "bootloader-boot-config",
  "bootloader_api",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-uefi"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-common",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader_api"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "rand",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,15 +31,15 @@ exclude = ["examples/basic", "examples/test_framework"]
 
 [workspace.package]
 # don't forget to update `workspace.dependencies` below
-version = "0.11.5"
+version = "0.11.6"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-osdev/bootloader"
 
 [workspace.dependencies]
-bootloader_api = { version = "0.11.5", path = "api" }
-bootloader-x86_64-common = { version = "0.11.5", path = "common" }
-bootloader-boot-config = { version = "0.11.5", path = "common/config" }
-bootloader-x86_64-bios-common = { version = "0.11.5", path = "bios/common" }
+bootloader_api = { version = "0.11.6", path = "api" }
+bootloader-x86_64-common = { version = "0.11.6", path = "common" }
+bootloader-boot-config = { version = "0.11.6", path = "common/config" }
+bootloader-x86_64-bios-common = { version = "0.11.6", path = "bios/common" }
 
 [features]
 default = ["bios", "uefi"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 # Unreleased
 
+# 0.11.6 – 2024-01-28
+
+* [Embed bios and uefi binaries](https://github.com/rust-osdev/bootloader/pull/395)
+* [Add a `take` method to `Optional`](https://github.com/rust-osdev/bootloader/pull/411)
+* [Fix data layout for stage 3 target](https://github.com/rust-osdev/bootloader/pull/413)
+
+**Full Changelog**: https://github.com/rust-osdev/bootloader/compare/v0.11.5...v0.11.6
+
 # 0.11.5 – 2023-12-28
 
 * [RacyCell<T>: Data race allowed on `T`](https://github.com/rust-osdev/bootloader/pull/390)


### PR DESCRIPTION
## What's Changed
* Embed bios and uefi binaries by @mysteriouslyseeing in https://github.com/rust-osdev/bootloader/pull/395
* Add a `take` method to `Optional` by @phil-opp in https://github.com/rust-osdev/bootloader/pull/411
* Fix data layout for stage 3 target by @phil-opp in https://github.com/rust-osdev/bootloader/pull/413
  * Fixes build on latest Rust nightly.

## New Contributors
* @mysteriouslyseeing made their first contribution in https://github.com/rust-osdev/bootloader/pull/395

**Full Changelog**: https://github.com/rust-osdev/bootloader/compare/v0.11.5...v0.11.6