### PR TITLE
[v0.9] Fix data layout for `x86_64-bootloader` target

### DIFF
--- a/example-kernel/x86_64-example-kernel.json
+++ b/example-kernel/x86_64-example-kernel.json
@@ -1,6 +1,6 @@
 {
     "llvm-target": "x86_64-unknown-none",
-    "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     "arch": "x86_64",
     "target-endian": "little",
     "target-pointer-width": "64",

--- a/test-kernel/x86_64-test-kernel.json
+++ b/test-kernel/x86_64-test-kernel.json
@@ -1,6 +1,6 @@
 {
     "llvm-target": "x86_64-unknown-none",
-    "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     "arch": "x86_64",
     "target-endian": "little",
     "target-pointer-width": "64",

--- a/x86_64-bootloader.json
+++ b/x86_64-bootloader.json
@@ -1,6 +1,6 @@
 {
     "llvm-target": "x86_64-unknown-none-gnu",
-    "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     "linker-flavor": "ld.lld",
     "linker": "rust-lld",
     "pre-link-args": {


### PR DESCRIPTION
Fixes build on latest Rust nightly.

See https://github.com/rust-lang/rust/pull/120062