### PR TITLE
adapt data layout to match LLVM's

### DIFF
--- a/bios/stage-4/src/main.rs
+++ b/bios/stage-4/src/main.rs
@@ -262,6 +262,9 @@ fn detect_rsdp() -> Option<PhysAddr> {
     #[derive(Clone)]
     struct IdentityMapped;
     impl AcpiHandler for IdentityMapped {
+        // TODO FIXME: This inline(never) annotation is required. Without it,
+        // LLVM replaces the `search_for_on_bios` call below with a `ud2`
+        // instruction. See https://github.com/rust-osdev/bootloader/issues/425
         #[inline(never)]
         unsafe fn map_physical_region<T>(
             &self,

--- a/bios/stage-4/src/main.rs
+++ b/bios/stage-4/src/main.rs
@@ -262,6 +262,7 @@ fn detect_rsdp() -> Option<PhysAddr> {
     #[derive(Clone)]
     struct IdentityMapped;
     impl AcpiHandler for IdentityMapped {
+        #[inline(never)]
         unsafe fn map_physical_region<T>(
             &self,
             physical_address: usize,

--- a/i386-code16-boot-sector.json
+++ b/i386-code16-boot-sector.json
@@ -1,7 +1,7 @@
 {
 	"arch": "x86",
 	"cpu": "i386",
-	"data-layout": "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-f64:32:64-f80:32-n8:16:32-S128",
+	"data-layout": "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i128:128-f64:32:64-f80:32-n8:16:32-S128",
 	"dynamic-linking": false,
 	"executables": true,
 	"linker-flavor": "ld.lld",

--- a/i386-code16-stage-2.json
+++ b/i386-code16-stage-2.json
@@ -1,7 +1,7 @@
 {
 	"arch": "x86",
 	"cpu": "i386",
-	"data-layout": "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-f64:32:64-f80:32-n8:16:32-S128",
+	"data-layout": "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i128:128-f64:32:64-f80:32-n8:16:32-S128",
 	"dynamic-linking": false,
 	"executables": true,
 	"linker-flavor": "ld.lld",

--- a/i686-stage-3.json
+++ b/i686-stage-3.json
@@ -1,7 +1,7 @@
 {
     "arch": "x86",
     "cpu": "i386",
-    "data-layout": "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-f64:32:64-f80:32-n8:16:32-S128",
+    "data-layout": "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i128:128-f64:32:64-f80:32-n8:16:32-S128",
     "dynamic-linking": false,
     "executables": true,
     "linker-flavor": "ld.lld",

--- a/x86_64-stage-4.json
+++ b/x86_64-stage-4.json
@@ -2,7 +2,7 @@
     "arch": "x86_64",
     "code-model": "kernel",
     "cpu": "x86-64",
-    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
     "disable-redzone": true,
     "features": "-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-3dnow,-3dnowa,-avx,-avx2,+soft-float",
     "linker": "rust-lld",


### PR DESCRIPTION
Update required because of https://github.com/rust-lang/rust/pull/116672, which became effective once https://github.com/rust-lang/rust/pull/120055 was merged.