### PR TITLE
[v0.9] Fix data layout for custom targets for LLVM 18

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- [Fix data layout for custom targets for LLVM 18](https://github.com/rust-osdev/bootloader/pull/421)
+  - Fixes build on latest Rust nightly
+
 # 0.9.24 – 2024-01-28
 
 - Fix data layout for `x86_64-bootloader` target ([#415](https://github.com/rust-osdev/bootloader/pull/415))

--- a/example-kernel/x86_64-example-kernel.json
+++ b/example-kernel/x86_64-example-kernel.json
@@ -1,6 +1,6 @@
 {
     "llvm-target": "x86_64-unknown-none",
-    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
     "arch": "x86_64",
     "target-endian": "little",
     "target-pointer-width": "64",

--- a/test-kernel/x86_64-test-kernel.json
+++ b/test-kernel/x86_64-test-kernel.json
@@ -1,6 +1,6 @@
 {
     "llvm-target": "x86_64-unknown-none",
-    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
     "arch": "x86_64",
     "target-endian": "little",
     "target-pointer-width": "64",

--- a/x86_64-bootloader.json
+++ b/x86_64-bootloader.json
@@ -1,6 +1,6 @@
 {
     "llvm-target": "x86_64-unknown-none-gnu",
-    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
     "linker-flavor": "ld.lld",
     "linker": "rust-lld",
     "pre-link-args": {


### PR DESCRIPTION
Fixes build on latest nightly, which was broken by the update to LLVM 18 in https://github.com/rust-lang/rust/pull/120055.