### PR TITLE
[v0.9] Fix map errors during kernel loading

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+
+- [Fix map errors during kernel loading](https://github.com/rust-osdev/bootloader/pull/422)
+    - Don't error if a kernel page is already mapped to the correct frame
+    - Fix: unmap temp page again to enable multiple bss-like sections
+
 # 0.9.25 – 2024-02-16
 
 - [Fix data layout for custom targets for LLVM 18](https://github.com/rust-osdev/bootloader/pull/421)

--- a/src/page_table.rs
+++ b/src/page_table.rs
@@ -124,7 +124,7 @@ pub(crate) fn map_segment(
                     unsafe {
                         map_page(
                             temp_page.clone(),
-                            new_frame.clone(),
+                            new_frame,
                             page_table_flags,
                             page_table,
                             frame_allocator,
@@ -152,6 +152,11 @@ pub(crate) fn map_segment(
                         });
                     }
 
+                    // unmap temp page again
+                    let (new_frame, flusher) = page_table.unmap(temp_page).unwrap();
+                    flusher.flush();
+
+                    // map last page to new frame
                     unsafe {
                         map_page(
                             last_page,


### PR DESCRIPTION
- Don't error if a kernel page is already mapped to the correct frame
- Fix: unmap temp page again to enable multiple bss-like sections
