### PR TITLE
[v0.9] Fix: unify flags if multiple segments are mapped to same frame with different flags

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,8 @@
 # Unreleased
 
-# 0.9.26 – 2024-02-16
+- [Fix: unify flags if multiple segments are mapped to same frame with different flags](https://github.com/rust-osdev/bootloader/pull/423)
 
+# 0.9.26 – 2024-02-16
 
 - [Fix map errors during kernel loading](https://github.com/rust-osdev/bootloader/pull/422)
     - Don't error if a kernel page is already mapped to the correct frame


### PR DESCRIPTION
Follow-up to #422 