### PR TITLE
Release `v0.11.7`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "async-process",
@@ -180,22 +180,22 @@ dependencies = [
 
 [[package]]
 name = "bootloader-boot-config"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bootloader-x86_64-bios-boot-sector"
-version = "0.11.6"
+version = "0.11.7"
 
 [[package]]
 name = "bootloader-x86_64-bios-common"
-version = "0.11.6"
+version = "0.11.7"
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-2"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "byteorder",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-3"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "noto-sans-mono-bitmap 0.1.6",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-4"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-bios-common",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-common"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "bootloader-boot-config",
  "bootloader_api",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-uefi"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-common",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader_api"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "rand",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,15 +31,15 @@ exclude = ["examples/basic", "examples/test_framework"]
 
 [workspace.package]
 # don't forget to update `workspace.dependencies` below
-version = "0.11.6"
+version = "0.11.7"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-osdev/bootloader"
 
 [workspace.dependencies]
-bootloader_api = { version = "0.11.6", path = "api" }
-bootloader-x86_64-common = { version = "0.11.6", path = "common" }
-bootloader-boot-config = { version = "0.11.6", path = "common/config" }
-bootloader-x86_64-bios-common = { version = "0.11.6", path = "bios/common" }
+bootloader_api = { version = "0.11.7", path = "api" }
+bootloader-x86_64-common = { version = "0.11.7", path = "common" }
+bootloader-boot-config = { version = "0.11.7", path = "common/config" }
+bootloader-x86_64-bios-common = { version = "0.11.7", path = "bios/common" }
 
 [features]
 default = ["bios", "uefi"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,12 @@
 # Unreleased
 
+# 0.11.7 – 2024-02-16
+
+* Set `NO_EXECUTE` flag for all writable memory regions by @phil-opp in https://github.com/rust-osdev/bootloader/pull/409
+* adapt data layout to match LLVM's by @tsatke in https://github.com/rust-osdev/bootloader/pull/420
+
+**Full Changelog**: https://github.com/rust-osdev/bootloader/compare/v0.11.6...v0.11.7
+
 # 0.11.6 – 2024-01-28
 
 * [Embed bios and uefi binaries](https://github.com/rust-osdev/bootloader/pull/395)


### PR DESCRIPTION
* Set `NO_EXECUTE` flag for all writable memory regions by @phil-opp in https://github.com/rust-osdev/bootloader/pull/409
* adapt data layout to match LLVM's by @tsatke in https://github.com/rust-osdev/bootloader/pull/420