### PR TITLE
avoid 32-bit relocation to __BOOTLOADER_CONFIG

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -140,6 +140,6 @@ macro_rules! entry_point {
 
 #[doc(hidden)]
 pub fn __force_use(slice: &&[u8; BootloaderConfig::SERIALIZED_LEN]) {
-    let force_use = slice.as_ptr() as usize;
+    let force_use = slice as *const _ as usize;
     unsafe { core::arch::asm!("add {0}, 0", in(reg) force_use, options(nomem, nostack)) };
 }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -130,7 +130,7 @@ macro_rules! entry_point {
                 let f: fn(&'static mut $crate::BootInfo) -> ! = $path;
 
                 // ensure that the config is used so that the linker keeps it
-                $crate::__force_use(__BOOTLOADER_CONFIG_REF);
+                $crate::__force_use(&__BOOTLOADER_CONFIG_REF);
 
                 f(boot_info)
             }
@@ -139,7 +139,7 @@ macro_rules! entry_point {
 }
 
 #[doc(hidden)]
-pub fn __force_use(slice: &[u8]) {
+pub fn __force_use(slice: &&[u8; BootloaderConfig::SERIALIZED_LEN]) {
     let force_use = slice.as_ptr() as usize;
     unsafe { core::arch::asm!("add {0}, 0", in(reg) force_use, options(nomem, nostack)) };
 }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -120,13 +120,17 @@ macro_rules! entry_point {
                 config.serialize()
             };
 
+            // Workaround for https://github.com/rust-osdev/bootloader/issues/427
+            static __BOOTLOADER_CONFIG_REF: &[u8; $crate::BootloaderConfig::SERIALIZED_LEN] =
+                &__BOOTLOADER_CONFIG;
+
             #[export_name = "_start"]
             pub extern "C" fn __impl_start(boot_info: &'static mut $crate::BootInfo) -> ! {
                 // validate the signature of the program entry point
                 let f: fn(&'static mut $crate::BootInfo) -> ! = $path;
 
                 // ensure that the config is used so that the linker keeps it
-                $crate::__force_use(&__BOOTLOADER_CONFIG);
+                $crate::__force_use(__BOOTLOADER_CONFIG_REF);
 
                 f(boot_info)
             }


### PR DESCRIPTION
As explained in my comment in #427, the compiler seems to have trouble emitting relocations for references to global variables in custom sections. For custom sections, it always emits 32-bit relocations even when a 64-bit relocation would be required. This patch works around that by never referencing the global in the custom section directly from code, but only through a pointer from another global variable in the non-custom .data section. The relocation used for the pointer in the global variable will always use a 64-bit relocation.

I tested the patch with these changes applied on top of this repo:
```diff
diff --git a/Cargo.toml b/Cargo.toml
index 94d582c..76e6832 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,9 +113,9 @@ lto = true
 [profile.test.package.test_kernel_higher_half]
 rustflags = [
     "-C",
-    "link-args=--image-base 0xFFFF800000000000",
+    "link-args=--image-base 0x00001eecb3620000",
     "-C",
-    "relocation-model=pic",
+    "relocation-model=static",
     "-C",
     "code-model=large",
 ]
```
Considering that there aren't many people using such an odd image base, I didn't add a test for this, but feel free to tell me if you want one.

Closes #427