### PR TITLE
CI: Fix macOS errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-12, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
 

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -106,6 +106,7 @@ mod version_info {
 ///   `#[link_section = ".bootloader-config"]`, which instructs the Rust compiler to store it
 ///   in a special section of the resulting ELF executable. From there, the bootloader will
 ///   automatically read it when loading the kernel.
+#[cfg(target_arch = "x86_64")]
 #[macro_export]
 macro_rules! entry_point {
     ($path:path) => {
@@ -139,6 +140,7 @@ macro_rules! entry_point {
 }
 
 #[doc(hidden)]
+#[cfg(target_arch = "x86_64")]
 pub fn __force_use(slice: &&[u8; BootloaderConfig::SERIALIZED_LEN]) {
     let force_use = slice as *const _ as usize;
     unsafe { core::arch::asm!("add {0}, 0", in(reg) force_use, options(nomem, nostack)) };


### PR DESCRIPTION
The `macos-latest` runner is ARM-based now, which causes some compile errors on CI. This PR adds back testing for x86_64-based macOS systems and some conditional compilation to enable limited testing on ARM-based systems.