### PR TITLE
[v0.9] Silence dead code warning

### DIFF
--- a/src/page_table.rs
+++ b/src/page_table.rs
@@ -17,7 +17,11 @@ pub struct MemoryInfo {
 
 #[derive(Debug)]
 pub enum MapKernelError {
-    Mapping(MapToError<Size4KiB>),
+    Mapping(
+        /// This field is never read, but still printed as part of the Debug output on error.
+        #[allow(dead_code)]
+        MapToError<Size4KiB>,
+    ),
     MultipleTlsSegments,
 }
 


### PR DESCRIPTION
The field is not read anywhere, but printed as part of the Debug output on error.

Fixes https://github.com/phil-opp/blog_os/issues/1317
