### PR TITLE
Ensure all page table frames are mapped as writable

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix bug leading to page table frames that are not mapped as writable
+
 # 0.11.7 – 2024-02-16
 
 * Set `NO_EXECUTE` flag for all writable memory regions by @phil-opp in https://github.com/rust-osdev/bootloader/pull/409

--- a/common/src/load_kernel.rs
+++ b/common/src/load_kernel.rs
@@ -185,8 +185,17 @@ where
             let offset = frame - start_frame;
             let page = start_page + offset;
             let flusher = unsafe {
+                // The parent table flags need to be both readable and writable to
+                // support recursive page tables.
+                // See https://github.com/rust-osdev/bootloader/issues/443#issuecomment-2130010621
                 self.page_table
-                    .map_to(page, frame, segment_flags, self.frame_allocator)
+                    .map_to_with_table_flags(
+                        page,
+                        frame,
+                        segment_flags,
+                        Flags::PRESENT | Flags::WRITABLE,
+                        self.frame_allocator,
+                    )
                     .map_err(|_err| "map_to failed")?
             };
             // we operate on an inactive page table, so there's no need to flush anything
@@ -280,8 +289,17 @@ where
 
             // map frame
             let flusher = unsafe {
+                // The parent table flags need to be both readable and writable to
+                // support recursive page tables.
+                // See https://github.com/rust-osdev/bootloader/issues/443#issuecomment-2130010621
                 self.page_table
-                    .map_to(page, frame, segment_flags, self.frame_allocator)
+                    .map_to_with_table_flags(
+                        page,
+                        frame,
+                        segment_flags,
+                        Flags::PRESENT | Flags::WRITABLE,
+                        self.frame_allocator,
+                    )
                     .map_err(|_err| "Failed to map new frame for bss memory")?
             };
             // we operate on an inactive page table, so we don't need to flush our changes


### PR DESCRIPTION
See #443 

This is a quick fix, for the issue above. That said I think this can still be improved for example we could use a `identity_map_with_table_flags` function in the x86 crate. 

Also as mentioned in the issue, maybe page table frames should be marked as `no_exec`. 