### PR TITLE
dont modify the bootloader's pagetables

### DIFF
--- a/bios/stage-4/src/main.rs
+++ b/bios/stage-4/src/main.rs
@@ -221,13 +221,6 @@ fn create_page_tables(frame_allocator: &mut impl FrameAllocator<Size4KiB>) -> Pa
     // We identity-mapped all memory, so the offset between physical and virtual addresses is 0
     let phys_offset = VirtAddr::new(0);
 
-    // copy the currently active level 4 page table, because it might be read-only
-    let bootloader_page_table = {
-        let frame = x86_64::registers::control::Cr3::read().0;
-        let table: *mut PageTable = (phys_offset + frame.start_address().as_u64()).as_mut_ptr();
-        unsafe { OffsetPageTable::new(&mut *table, phys_offset) }
-    };
-
     // create a new page table hierarchy for the kernel
     let (kernel_page_table, kernel_level_4_frame) = {
         // get an unused frame for new level 4 page table
@@ -246,7 +239,6 @@ fn create_page_tables(frame_allocator: &mut impl FrameAllocator<Size4KiB>) -> Pa
     };
 
     PageTables {
-        bootloader: bootloader_page_table,
         kernel: kernel_page_table,
         kernel_level_4_frame,
     }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -605,8 +605,6 @@ pub fn switch_to_kernel(page_tables: PageTables, mappings: Mappings, boot_info: 
 
 /// Provides access to the page tables of the bootloader and kernel address space.
 pub struct PageTables {
-    /// Provides access to the page tables of the bootloader address space.
-    pub bootloader: OffsetPageTable<'static>,
     /// Provides access to the page tables of the kernel address space (not active).
     pub kernel: OffsetPageTable<'static>,
     /// The physical frame where the level 4 page table of the kernel address space is stored.


### PR DESCRIPTION
Don't modify the bootloader's page tables.
Previously we assumed that the page tables set up by UEFI would only contain relevant mappings in the first PML4 entry, but it turns out that some implementations map the frame buffer into address space ranges mapped by later PML4 entries. As a result, we can no longer just remove all but the first PML4 entry. The problem is that because we've assumed that only the first PML4 entry is used, we've been mapping memory into the address ranges covered by other PML4 entries, but that may no longer work if UEFI already happened to have mapped some memory there.
Fortunately, there's only a single location where we've been mapping memory into the bootloader page tables: We mapped the boot info and memory map into both the bootloader and kernel address spaces so that we can simply create references to them and pass them directly from the bootloader to the kernel. Instead, we now only map memory into the bootloader's address space. When we need to access the memory from the bootloader, we traverse the kernel's page tables to look up the physical address and use the identify mappings to access the physical memory. This is mostly consistent with how we access the kernel's memory in other places.

@colepng Could you please test that this resolves the issue on your system?

Supersedes #464
Closes #462