### PR TITLE
release v0.11.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "anyhow",
  "async-process",
@@ -182,22 +182,22 @@ dependencies = [
 
 [[package]]
 name = "bootloader-boot-config"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bootloader-x86_64-bios-boot-sector"
-version = "0.11.7"
+version = "0.11.8"
 
 [[package]]
 name = "bootloader-x86_64-bios-common"
-version = "0.11.7"
+version = "0.11.8"
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-2"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "byteorder",
@@ -206,7 +206,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-3"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "noto-sans-mono-bitmap 0.1.6",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-4"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-bios-common",
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-common"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "bootloader-boot-config",
  "bootloader_api",
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-uefi"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-common",
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader_api"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "rand",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,15 +33,15 @@ exclude = ["examples/basic", "examples/test_framework"]
 
 [workspace.package]
 # don't forget to update `workspace.dependencies` below
-version = "0.11.7"
+version = "0.11.8"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-osdev/bootloader"
 
 [workspace.dependencies]
-bootloader_api = { version = "0.11.7", path = "api" }
-bootloader-x86_64-common = { version = "0.11.7", path = "common" }
-bootloader-boot-config = { version = "0.11.7", path = "common/config" }
-bootloader-x86_64-bios-common = { version = "0.11.7", path = "bios/common" }
+bootloader_api = { version = "0.11.8", path = "api" }
+bootloader-x86_64-common = { version = "0.11.8", path = "common" }
+bootloader-boot-config = { version = "0.11.8", path = "common/config" }
+bootloader-x86_64-bios-common = { version = "0.11.8", path = "bios/common" }
 
 [features]
 default = ["bios", "uefi"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,17 @@
 # Unreleased
 
-* Fix bug leading to page table frames that are not mapped as writable
+# 0.11.8 – 2024-11-02
+
+* [avoid 32-bit relocation to __BOOTLOADER_CONFIG](https://github.com/rust-osdev/bootloader/pull/428)
+* [Fix doc comment and error message only referencing the BIOS but used for UEFI](https://github.com/rust-osdev/bootloader/pull/439)
+* [Ensure all page table frames are mapped as writable](https://github.com/rust-osdev/bootloader/pull/444)
+* [Guard the lower 1MB of memory](https://github.com/rust-osdev/bootloader/pull/446)
+* [always cover at least the first 4 GiB of physical memory](https://github.com/rust-osdev/bootloader/pull/448)
+* [Fixed "jc fail" instructions not working properly and updated README.md](https://github.com/rust-osdev/bootloader/pull/453)
+* [Remove 3dnow features from stage4 target](https://github.com/rust-osdev/bootloader/pull/471)
+* [mention E820 in docs for UnknownBios](https://github.com/rust-osdev/bootloader/pull/461)
+
+**Full Changelog**: https://github.com/rust-osdev/bootloader/compare/v0.11.7...v0.11.8
 
 # 0.11.7 – 2024-02-16
 


### PR DESCRIPTION
* [avoid 32-bit relocation to __BOOTLOADER_CONFIG](https://github.com/rust-osdev/bootloader/pull/428)
* [Fix doc comment and error message only referencing the BIOS but used for UEFI](https://github.com/rust-osdev/bootloader/pull/439)
* [Ensure all page table frames are mapped as writable](https://github.com/rust-osdev/bootloader/pull/444)
* [Guard the lower 1MB of memory](https://github.com/rust-osdev/bootloader/pull/446)
* [always cover at least the first 4 GiB of physical memory](https://github.com/rust-osdev/bootloader/pull/448)
* [Fixed "jc fail" instructions not working properly and updated README.md](https://github.com/rust-osdev/bootloader/pull/453)
* [Remove 3dnow features from stage4 target](https://github.com/rust-osdev/bootloader/pull/471)
* [mention E820 in docs for UnknownBios](https://github.com/rust-osdev/bootloader/pull/461)

Cc @mrjbom