### PR TITLE
Remove 3dnow features from stage4 target

### DIFF
--- a/x86_64-stage-4.json
+++ b/x86_64-stage-4.json
@@ -4,7 +4,7 @@
     "cpu": "x86-64",
     "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
     "disable-redzone": true,
-    "features": "-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-3dnow,-3dnowa,-avx,-avx2,+soft-float",
+    "features": "-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-avx,-avx2,+soft-float",
     "linker": "rust-lld",
     "linker-flavor": "ld.lld",
     "llvm-target": "x86_64-unknown-none-elf",


### PR DESCRIPTION
Remove the 3dnow features from the stage4 target since rust [removed](https://github.com/rust-lang/rust/pull/127864) support for them.

This silences the following messages while building:

```bash
'-3dnow' is not a recognized feature for this target (ignoring feature)
'-3dnowa' is not a recognized feature for this target (ignoring feature)
```