### PR TITLE
Convert LF to CRLF when writing to serial port

### DIFF
--- a/common/src/serial.rs
+++ b/common/src/serial.rs
@@ -17,7 +17,12 @@ impl SerialPort {
 
 impl fmt::Write for SerialPort {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        self.port.write_str(s).unwrap();
+        for char in s.bytes() {
+            match char {
+                b'\n' => self.port.write_str("\r\n").unwrap(),
+                byte => self.port.send(byte),
+            }
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
Fixes #473 

I'm not sure if this is the best way to implement this in terms of performance.

~~This fixes the issue with `LockedLogger`, but the logging that gets done before that still doesn't use CRLF, which is why I marked this as a draft PR.~~ UPDATE: I forgot to change the `bootloader` dependency in Cargo.toml, after changing it all logging was as expected.

Without this change
![image](https://github.com/user-attachments/assets/f81c5b9a-aaa9-4783-931c-caa1c40d1814)


With this change:
![image](https://github.com/user-attachments/assets/e08a9678-93e5-4492-b35a-b760de4418dd)
