### PR TITLE
fix condition for running bootloader common tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Run api tests
         run: cargo test -p bootloader_api
       - name: Run bootloader common tests
-        if: runner.arch == 'x86'
+        if: runner.arch == 'X64'
         run: cargo test -p bootloader-x86_64-common
       - name: Run integration tests
         run: cargo test -- --test-threads 1


### PR DESCRIPTION
There's no 'x86' arch. There is 'X86', but we currently don't any CI job on a 32-bit target, so this still wouldn't work. Let's just use X64.