### PR TITLE
change rustc-abi in custom targets to x86-softfloat

### DIFF
--- a/i686-stage-3.json
+++ b/i686-stage-3.json
@@ -17,5 +17,6 @@
     "os": "none",
     "vendor": "unknown",
     "relocation-model": "static",
-    "features": "+soft-float,-sse,-mmx"
+    "features": "+soft-float,-sse,-mmx",
+    "rustc-abi": "x86-softfloat"
 }

--- a/x86_64-stage-4.json
+++ b/x86_64-stage-4.json
@@ -18,5 +18,6 @@
     "static-position-independent-executables": true,
     "target-pointer-width": "64",
     "relocation-model": "static",
-    "os": "none"
+    "os": "none",
+    "rustc-abi": "x86-softfloat"
 }


### PR DESCRIPTION
With the latest nightly, setting "+soft-float" in "features" is only allowed if "rustc-abi" is set to "x86-softfloat".

Fixes a nightly breakage introduced by https://github.com/rust-lang/rust/pull/136146