### PR TITLE
change rustc-abi in custom targets to x86-softfloat

### DIFF
--- a/example-kernel/x86_64-example-kernel.json
+++ b/example-kernel/x86_64-example-kernel.json
@@ -11,5 +11,6 @@
     "linker": "rust-lld",
     "panic-strategy": "abort",
     "disable-redzone": true,
-    "features": "-mmx,-sse,+soft-float"
+    "features": "-mmx,-sse,+soft-float",
+    "rustc-abi": "x86-softfloat"
   }

--- a/test-kernel/x86_64-test-kernel.json
+++ b/test-kernel/x86_64-test-kernel.json
@@ -11,5 +11,6 @@
     "linker": "rust-lld",
     "panic-strategy": "abort",
     "disable-redzone": true,
-    "features": "-mmx,-sse,+soft-float"
+    "features": "-mmx,-sse,+soft-float",
+    "rustc-abi": "x86-softfloat"
   }

--- a/x86_64-bootloader.json
+++ b/x86_64-bootloader.json
@@ -18,5 +18,6 @@
     "disable-redzone": true,
     "panic-strategy": "abort",
     "executables": true,
-    "relocation-model": "static"
+    "relocation-model": "static",
+    "rustc-abi": "x86-softfloat"
 }


### PR DESCRIPTION
With the latest nightly, setting "+soft-float" in "features" is only allowed if "rustc-abi" is set to "x86-softfloat".

Fixes a nightly breakage introduced by https://github.com/rust-lang/rust/pull/136146
Related to #491