### PR TITLE
Release `v0.11.10`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "anyhow",
  "bootloader-boot-config",
@@ -94,22 +94,22 @@ dependencies = [
 
 [[package]]
 name = "bootloader-boot-config"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bootloader-x86_64-bios-boot-sector"
-version = "0.11.9"
+version = "0.11.10"
 
 [[package]]
 name = "bootloader-x86_64-bios-common"
-version = "0.11.9"
+version = "0.11.10"
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-2"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "byteorder",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-3"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "noto-sans-mono-bitmap 0.1.6",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-4"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-bios-common",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-common"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "bootloader-boot-config",
  "bootloader_api",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-uefi"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-common",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader_api"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "rand",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,15 +22,15 @@ exclude = ["examples/basic", "examples/test_framework", "tests/test_kernels/*"]
 
 [workspace.package]
 # don't forget to update `workspace.dependencies` below
-version = "0.11.9"
+version = "0.11.10"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-osdev/bootloader"
 
 [workspace.dependencies]
-bootloader_api = { version = "0.11.8", path = "api" }
-bootloader-x86_64-common = { version = "0.11.8", path = "common" }
-bootloader-boot-config = { version = "0.11.8", path = "common/config" }
-bootloader-x86_64-bios-common = { version = "0.11.8", path = "bios/common" }
+bootloader_api = { version = "0.11.10", path = "api" }
+bootloader-x86_64-common = { version = "0.11.10", path = "common" }
+bootloader-boot-config = { version = "0.11.10", path = "common/config" }
+bootloader-x86_64-bios-common = { version = "0.11.10", path = "bios/common" }
 
 [features]
 default = ["bios", "uefi"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,11 +1,15 @@
 # Unreleased
 
+# 0.11.10 – 2025-02-10
+
 * [Remove "UEFI boot" log message](https://github.com/rust-osdev/bootloader/pull/476)
 * [use threads instead of futures in build.rs](https://github.com/rust-osdev/bootloader/pull/484)
 * [Move test kernels to a separate workspace](https://github.com/rust-osdev/bootloader/pull/486)
 * [fix condition for running bootloader common tests](https://github.com/rust-osdev/bootloader/pull/487)
 * [Update `x86_64` to `0.15.2`](https://github.com/rust-osdev/bootloader/pull/490)
 * [change rustc-abi in custom targets to x86-softfloat](https://github.com/rust-osdev/bootloader/pull/491)
+
+**Full Changelog**: https://github.com/rust-osdev/bootloader/compare/v0.11.9...v0.11.10
 
 # 0.11.9 – 2024-11-30
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,12 @@
 # Unreleased
 
+* [Remove "UEFI boot" log message](https://github.com/rust-osdev/bootloader/pull/476)
+* [use threads instead of futures in build.rs](https://github.com/rust-osdev/bootloader/pull/484)
+* [Move test kernels to a separate workspace](https://github.com/rust-osdev/bootloader/pull/486)
+* [fix condition for running bootloader common tests](https://github.com/rust-osdev/bootloader/pull/487)
+* [Update `x86_64` to `0.15.2`](https://github.com/rust-osdev/bootloader/pull/490)
+* [change rustc-abi in custom targets to x86-softfloat](https://github.com/rust-osdev/bootloader/pull/491)
+
 # 0.11.9 – 2024-11-30
 
 This release is compatible with Rust nightlies starting with `nightly-2024-11-23`.


### PR DESCRIPTION
Changelog:

* [Remove "UEFI boot" log message](https://github.com/rust-osdev/bootloader/pull/476)
* [use threads instead of futures in build.rs](https://github.com/rust-osdev/bootloader/pull/484)
* [Move test kernels to a separate workspace](https://github.com/rust-osdev/bootloader/pull/486)
* [fix condition for running bootloader common tests](https://github.com/rust-osdev/bootloader/pull/487)
* [Update `x86_64` to `0.15.2`](https://github.com/rust-osdev/bootloader/pull/490)
* [change rustc-abi in custom targets to x86-softfloat](https://github.com/rust-osdev/bootloader/pull/491)