### PR TITLE
Update uart_16550 to 0.3.2

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -19,7 +19,7 @@ xmas-elf = "0.8.0"
 raw-cpuid = "10.2.0"
 rand = { version = "0.8.4", default-features = false }
 rand_hc = "0.3.1"
-uart_16550 = "0.2.18"
+uart_16550 = "0.3.2"
 log = "0.4.17"
 
 [dependencies.noto-sans-mono-bitmap]


### PR DESCRIPTION
Hey,

updating my current project to the 0.15 version of the x86_64 crate introduces compiling issues since the uart_16550 crate version 0.2.18 refers to the x86_64 crate version 0.14. Here is an output from `cargo tree`:

```
├── bootloader-x86_64-common v0.11.10
│   ├── bootloader-boot-config v0.11.10
...
│   ├── bootloader_api v0.11.10
...
│   ├── uart_16550 v0.2.19
...
│   │   └── x86_64 v0.14.13
...
│   ├── x86_64 v0.15.2
...
```

I have updated uart_16550 accordingly. It does not depend on x86_64 anymore with version 0.3.2.

Best Regards