### PR TITLE
implement Send+Sync for MemoryRegions

### DIFF
--- a/api/src/info.rs
+++ b/api/src/info.rs
@@ -132,6 +132,9 @@ impl From<MemoryRegions> for &'static mut [MemoryRegion] {
     }
 }
 
+unsafe impl Send for MemoryRegions {}
+unsafe impl Sync for MemoryRegions {}
+
 /// Represent a physical memory region.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(C)]


### PR DESCRIPTION
This also makes BootInfo Send+Sync. It's now possible to store BootInfo in a static without resorting to unsafe code.