### PR TITLE
Document physical memory mapping size

### DIFF
--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -386,9 +386,15 @@ pub struct Mappings {
     pub boot_info: Mapping,
     /// Specifies the mapping of the frame buffer memory region.
     pub framebuffer: Mapping,
-    /// The bootloader supports to map the whole physical memory into the virtual address
+    /// The bootloader supports mapping the whole physical memory into the virtual address
     /// space at some offset. This is useful for accessing and modifying the page tables set
     /// up by the bootloader.
+    ///
+    /// This mapping will go from physical address `0x0` to whichever is larger:
+    /// - The end of the last region in the BIOS/UEFI memory map
+    /// - The address `0x1_0000_0000` (such that at least 4 GiB of physical memory are always mapped).
+    /// This is to ensure that useful MMIO regions (local APIC, I/O APIC, PCI bars) are
+    /// accessible to the kernel even if less physical memory than that is on the system.
     ///
     /// Defaults to `None`, i.e. no mapping of the physical memory.
     pub physical_memory: Option<Mapping>,


### PR DESCRIPTION
In developing an AHCI driver, I noticed that the addresses that UEFI loads the MMIO structures into were higher than the final memory region given by the memory map. Since I was using that final region to determine the size of the bootloader-provided physical memory map, I didn't know how far the map "truly" extended.

Digging into the source code (`common/src/legacy_memory_region.rs:141`) I noticed that the bootloader continues mapping up to 4 GiB, even if less than that is on the system (I had QEMU set to 2). Since this didn't (seem to be) documented, I added a note to the rustdoc on the physical map settings explaining this. Also fixed a typo on the same rustdoc.