### PR TITLE
Fixes the type of target-c-int-width in target jsons.

### DIFF
--- a/i386-code16-boot-sector.json
+++ b/i386-code16-boot-sector.json
@@ -10,7 +10,7 @@
 	"max-atomic-width": 64,
 	"position-independent-executables": false,
 	"disable-redzone": true,
-	"target-c-int-width": "32",
+	"target-c-int-width": 32,
 	"target-pointer-width": "32",
 	"target-endian": "little",
 	"panic-strategy": "abort",

--- a/i386-code16-stage-2.json
+++ b/i386-code16-stage-2.json
@@ -10,7 +10,7 @@
 	"max-atomic-width": 64,
 	"position-independent-executables": false,
 	"disable-redzone": true,
-	"target-c-int-width": "32",
+	"target-c-int-width": 32,
 	"target-pointer-width": "32",
 	"target-endian": "little",
 	"panic-strategy": "abort",

--- a/i686-stage-3.json
+++ b/i686-stage-3.json
@@ -10,7 +10,7 @@
     "max-atomic-width": 64,
     "position-independent-executables": false,
     "disable-redzone": true,
-    "target-c-int-width": "32",
+    "target-c-int-width": 32,
     "target-pointer-width": "32",
     "target-endian": "little",
     "panic-strategy": "abort",


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/144218, the type of target-c-int-width was changed to an Option<u16>, when previously it could be parsed from a string.
That change caused an error "error: error loading target specification: target-c-int-width: invalid type: string "32", expected u16 at line 13 column 27"
This pr is meant to fix that, by changing the value in the jsons from "32" to 32.