### PR TITLE
release v0.11.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
  "rand_hc",
  "raw-cpuid",
  "spinning_top",
- "uart_16550",
+ "uart_16550 0.3.2",
  "usize_conversions",
  "x86_64 0.15.2",
  "xmas-elf",
@@ -734,7 +734,7 @@ name = "test_kernel_config_file"
 version = "0.1.0"
 dependencies = [
  "bootloader_api",
- "uart_16550",
+ "uart_16550 0.2.18",
  "x86_64 0.15.2",
 ]
 
@@ -743,7 +743,7 @@ name = "test_kernel_default_settings"
 version = "0.1.0"
 dependencies = [
  "bootloader_api",
- "uart_16550",
+ "uart_16550 0.2.18",
  "x86_64 0.15.2",
 ]
 
@@ -752,7 +752,7 @@ name = "test_kernel_fixed_kernel_address"
 version = "0.1.0"
 dependencies = [
  "bootloader_api",
- "uart_16550",
+ "uart_16550 0.2.18",
  "x86_64 0.15.2",
 ]
 
@@ -761,7 +761,7 @@ name = "test_kernel_higher_half"
 version = "0.1.0"
 dependencies = [
  "bootloader_api",
- "uart_16550",
+ "uart_16550 0.2.18",
  "x86_64 0.15.2",
 ]
 
@@ -770,7 +770,7 @@ name = "test_kernel_lower_memory_free"
 version = "0.1.0"
 dependencies = [
  "bootloader_api",
- "uart_16550",
+ "uart_16550 0.2.18",
  "x86_64 0.15.2",
 ]
 
@@ -779,7 +779,7 @@ name = "test_kernel_map_phys_mem"
 version = "0.1.0"
 dependencies = [
  "bootloader_api",
- "uart_16550",
+ "uart_16550 0.2.18",
  "x86_64 0.15.2",
 ]
 
@@ -788,7 +788,7 @@ name = "test_kernel_min_stack"
 version = "0.1.0"
 dependencies = [
  "bootloader_api",
- "uart_16550",
+ "uart_16550 0.2.18",
  "x86_64 0.15.2",
 ]
 
@@ -797,7 +797,7 @@ name = "test_kernel_pie"
 version = "0.1.0"
 dependencies = [
  "bootloader_api",
- "uart_16550",
+ "uart_16550 0.2.18",
  "x86_64 0.15.2",
 ]
 
@@ -806,7 +806,7 @@ name = "test_kernel_ramdisk"
 version = "0.1.0"
 dependencies = [
  "bootloader_api",
- "uart_16550",
+ "uart_16550 0.2.18",
  "x86_64 0.15.2",
 ]
 
@@ -815,7 +815,7 @@ name = "test_kernel_write_usable_memory"
 version = "0.1.0"
 dependencies = [
  "bootloader_api",
- "uart_16550",
+ "uart_16550 0.2.18",
  "x86_64 0.15.2",
 ]
 
@@ -848,6 +848,17 @@ dependencies = [
  "bitflags 1.3.2",
  "rustversion",
  "x86_64 0.14.13",
+]
+
+[[package]]
+name = "uart_16550"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e492212ac378a5e00da953718dafb1340d9fbaf4f27d6f3c5cab03d931d1c049"
+dependencies = [
+ "bitflags 2.3.3",
+ "rustversion",
+ "x86",
 ]
 
 [[package]]
@@ -1016,6 +1027,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x86"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2781db97787217ad2a2845c396a5efe286f87467a5810836db6d74926e94a385"
+dependencies = [
+ "bit_field",
+ "bitflags 1.3.2",
+ "raw-cpuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "anyhow",
  "bootloader-boot-config",
@@ -95,22 +95,22 @@ dependencies = [
 
 [[package]]
 name = "bootloader-boot-config"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bootloader-x86_64-bios-boot-sector"
-version = "0.11.10"
+version = "0.11.11"
 
 [[package]]
 name = "bootloader-x86_64-bios-common"
-version = "0.11.10"
+version = "0.11.11"
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-2"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "byteorder",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-3"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "noto-sans-mono-bitmap 0.1.6",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-4"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-bios-common",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-common"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "bootloader-boot-config",
  "bootloader_api",
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-uefi"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-common",
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader_api"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "rand",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,15 +22,15 @@ exclude = ["examples/basic", "examples/test_framework", "tests/test_kernels/*"]
 
 [workspace.package]
 # don't forget to update `workspace.dependencies` below
-version = "0.11.10"
+version = "0.11.11"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-osdev/bootloader"
 
 [workspace.dependencies]
-bootloader_api = { version = "0.11.10", path = "api" }
-bootloader-x86_64-common = { version = "0.11.10", path = "common" }
-bootloader-boot-config = { version = "0.11.10", path = "common/config" }
-bootloader-x86_64-bios-common = { version = "0.11.10", path = "bios/common" }
+bootloader_api = { version = "0.11.11", path = "api" }
+bootloader-x86_64-common = { version = "0.11.11", path = "common" }
+bootloader-boot-config = { version = "0.11.11", path = "common/config" }
+bootloader-x86_64-bios-common = { version = "0.11.11", path = "bios/common" }
 
 [features]
 default = ["bios", "uefi"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,17 @@
 # Unreleased
 
-## Features
+# 0.11.11 – 2025-07-31
 
-* add `kernel_base` mapping to the BootloaderConfig to specify the virtual address
-    at which position-independent kernels are loaded.
+This release is compatible with Rust nightlies starting with `nightly-2025-07-24`.
 
+* [Update uart_16550 to 0.3.2](https://github.com/rust-osdev/bootloader/pull/495)
+* [add `kernel_base` mapping to the BootloaderConfig](https://github.com/rust-osdev/bootloader/pull/494)
+* [Use Result::ok](https://github.com/rust-osdev/bootloader/pull/496)
+* [implement Send+Sync for MemoryRegions](https://github.com/rust-osdev/bootloader/pull/502)
+* [Document physical memory mapping size](https://github.com/rust-osdev/bootloader/pull/506)
+* [Fixes the type of target-c-int-width in target jsons. #](https://github.com/rust-osdev/bootloader/pull/509)
+
+**Full Changelog**: https://github.com/rust-osdev/bootloader/compare/v0.11.10...v0.11.11
 
 # 0.11.10 – 2025-02-10
 


### PR DESCRIPTION
This release is compatible with Rust nightlies starting with `nightly-2025-07-24`.

* [Update uart_16550 to 0.3.2](https://github.com/rust-osdev/bootloader/pull/495)
* [add `kernel_base` mapping to the BootloaderConfig](https://github.com/rust-osdev/bootloader/pull/494)
* [Use Result::ok](https://github.com/rust-osdev/bootloader/pull/496)
* [implement Send+Sync for MemoryRegions](https://github.com/rust-osdev/bootloader/pull/502)
* [Document physical memory mapping size](https://github.com/rust-osdev/bootloader/pull/506)
* [Fixes the type of target-c-int-width in target jsons. #](https://github.com/rust-osdev/bootloader/pull/509)
