### PR TITLE
fix target-c-int-width for 0.9.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bootloader"
-version = "0.9.31"
+version = "0.9.32"
 dependencies = [
  "bit_field",
  "fixedvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bootloader"
-version = "0.9.31"
+version = "0.9.32"
 authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 license = "MIT/Apache-2.0"
 description = "An experimental pure-Rust x86 bootloader."

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 0.9.32 – 2025-07-31
+
+- [fix target-c-int-width](https://github.com/rust-osdev/bootloader/pull/512)
+
 # 0.9.31 – 2025-03-22
 
 - [remove #[no_mangle] from panic handler](https://github.com/rust-osdev/bootloader/pull/500)

--- a/example-kernel/x86_64-example-kernel.json
+++ b/example-kernel/x86_64-example-kernel.json
@@ -4,7 +4,7 @@
     "arch": "x86_64",
     "target-endian": "little",
     "target-pointer-width": "64",
-    "target-c-int-width": "32",
+    "target-c-int-width": 32,
     "os": "none",
     "executables": true,
     "linker-flavor": "ld.lld",

--- a/test-kernel/x86_64-test-kernel.json
+++ b/test-kernel/x86_64-test-kernel.json
@@ -4,7 +4,7 @@
     "arch": "x86_64",
     "target-endian": "little",
     "target-pointer-width": "64",
-    "target-c-int-width": "32",
+    "target-c-int-width": 32,
     "os": "none",
     "executables": true,
     "linker-flavor": "ld.lld",

--- a/x86_64-bootloader.json
+++ b/x86_64-bootloader.json
@@ -11,7 +11,7 @@
     },
     "target-endian": "little",
     "target-pointer-width": "64",
-    "target-c-int-width": "32",
+    "target-c-int-width": 32,
     "arch": "x86_64",
     "os": "none",
     "features": "-mmx,-sse,+soft-float",


### PR DESCRIPTION
Newer rustc versions require this value to be an integer.

For more information see #509.

Closes #511