### PR TITLE
Fix: `target-pointer-width` field now expects an integer

### DIFF
--- a/i386-code16-boot-sector.json
+++ b/i386-code16-boot-sector.json
@@ -11,7 +11,7 @@
 	"position-independent-executables": false,
 	"disable-redzone": true,
 	"target-c-int-width": 32,
-	"target-pointer-width": "32",
+	"target-pointer-width": 32,
 	"target-endian": "little",
 	"panic-strategy": "abort",
 	"os": "none",

--- a/i386-code16-stage-2.json
+++ b/i386-code16-stage-2.json
@@ -11,7 +11,7 @@
 	"position-independent-executables": false,
 	"disable-redzone": true,
 	"target-c-int-width": 32,
-	"target-pointer-width": "32",
+	"target-pointer-width": 32,
 	"target-endian": "little",
 	"panic-strategy": "abort",
 	"os": "none",

--- a/i686-stage-3.json
+++ b/i686-stage-3.json
@@ -11,7 +11,7 @@
     "position-independent-executables": false,
     "disable-redzone": true,
     "target-c-int-width": 32,
-    "target-pointer-width": "32",
+    "target-pointer-width": 32,
     "target-endian": "little",
     "panic-strategy": "abort",
     "os": "none",

--- a/x86_64-stage-4.json
+++ b/x86_64-stage-4.json
@@ -16,7 +16,7 @@
         "kind": "call"
     },
     "static-position-independent-executables": true,
-    "target-pointer-width": "64",
+    "target-pointer-width": 64,
     "relocation-model": "static",
     "os": "none",
     "rustc-abi": "x86-softfloat"


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/144443
