### PR TITLE
Release `v0.11.12`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "anyhow",
  "bootloader-boot-config",
@@ -95,22 +95,22 @@ dependencies = [
 
 [[package]]
 name = "bootloader-boot-config"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bootloader-x86_64-bios-boot-sector"
-version = "0.11.11"
+version = "0.11.12"
 
 [[package]]
 name = "bootloader-x86_64-bios-common"
-version = "0.11.11"
+version = "0.11.12"
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-2"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "byteorder",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-3"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "noto-sans-mono-bitmap 0.1.6",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-4"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-bios-common",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-common"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "bootloader-boot-config",
  "bootloader_api",
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-uefi"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-common",
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader_api"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "rand",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,15 +22,15 @@ exclude = ["examples/basic", "examples/test_framework", "tests/test_kernels/*"]
 
 [workspace.package]
 # don't forget to update `workspace.dependencies` below
-version = "0.11.11"
+version = "0.11.12"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-osdev/bootloader"
 
 [workspace.dependencies]
-bootloader_api = { version = "0.11.11", path = "api" }
-bootloader-x86_64-common = { version = "0.11.11", path = "common" }
-bootloader-boot-config = { version = "0.11.11", path = "common/config" }
-bootloader-x86_64-bios-common = { version = "0.11.11", path = "bios/common" }
+bootloader_api = { version = "0.11.12", path = "api" }
+bootloader-x86_64-common = { version = "0.11.12", path = "common" }
+bootloader-boot-config = { version = "0.11.12", path = "common/config" }
+bootloader-x86_64-bios-common = { version = "0.11.12", path = "bios/common" }
 
 [features]
 default = ["bios", "uefi"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+# 0.11.12 - 2025-09-03
+
+This release is compatible with Rust nightlies starting with `nightly-2025-08-28`.
+
+* [Fix: `target-pointer-width` field now expects an integer](https://github.com/rust-osdev/bootloader/pull/516)
+
 # 0.11.11 – 2025-07-31
 
 This release is compatible with Rust nightlies starting with `nightly-2025-07-24`.

--- a/tests/test_kernels/Cargo.lock
+++ b/tests/test_kernels/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bootloader_api"
-version = "0.11.10"
+version = "0.11.11"
 
 [[package]]
 name = "rustversion"


### PR DESCRIPTION
This release is compatible with Rust nightlies starting with `nightly-2025-08-28`.

* [Fix: `target-pointer-width` field now expects an integer](https://github.com/rust-osdev/bootloader/pull/516)