### PR TITLE
Fix(v0.9): target-pointer-width field now expects an integer

### DIFF
--- a/example-kernel/x86_64-example-kernel.json
+++ b/example-kernel/x86_64-example-kernel.json
@@ -3,7 +3,7 @@
     "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
     "arch": "x86_64",
     "target-endian": "little",
-    "target-pointer-width": "64",
+    "target-pointer-width": 64,
     "target-c-int-width": 32,
     "os": "none",
     "executables": true,

--- a/test-kernel/x86_64-test-kernel.json
+++ b/test-kernel/x86_64-test-kernel.json
@@ -3,7 +3,7 @@
     "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
     "arch": "x86_64",
     "target-endian": "little",
-    "target-pointer-width": "64",
+    "target-pointer-width": 64,
     "target-c-int-width": 32,
     "os": "none",
     "executables": true,

--- a/x86_64-bootloader.json
+++ b/x86_64-bootloader.json
@@ -10,7 +10,7 @@
         ]
     },
     "target-endian": "little",
-    "target-pointer-width": "64",
+    "target-pointer-width": 64,
     "target-c-int-width": 32,
     "arch": "x86_64",
     "os": "none",


### PR DESCRIPTION
See rust-lang/rust#144443
