### PR TITLE
Fix stage 2 build by moving `.bss` section

### DIFF
--- a/bios/stage-2/stage-2-link.ld
+++ b/bios/stage-2/stage-2-link.ld
@@ -6,11 +6,11 @@ SECTIONS {
     .start : {
         *(.start)
     }
-    .text : {
-        *(.text .text.*)
-    }
     .bss : {
         *(.bss .bss.*)
+    }
+    .text : {
+        *(.text .text.*)
     }
     .rodata : {
         *(.rodata .rodata.*)


### PR DESCRIPTION
We get `relocation R_386_16 out of range: 74743 is not in [-32768, 65535]` errors with the latest nightlies, as reported in #520. All the failed relocations are from the `.start` section, referencing the `.bss` section. This commit fixes these errors by moving the `.bss` section in between the `.start` and `.text` sections so that it is closer to the `.start` section.

Fixes #520