### PR TITLE
Use legacy symbol mangling for BIOS stage 2

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -215,6 +215,10 @@ fn build_bios_stage_2() -> PathBuf {
     cmd.env_remove("RUSTFLAGS");
     cmd.env_remove("CARGO_ENCODED_RUSTFLAGS");
     cmd.env_remove("RUSTC_WORKSPACE_WRAPPER"); // used by clippy
+    cmd.env(
+        "RUSTFLAGS",
+        "-Csymbol-mangling-version=legacy -Zunstable-options",
+    );
     let status = cmd
         .status()
         .expect("failed to run cargo install for bios second stage");


### PR DESCRIPTION
The new v0 mangling of Rust seems to have broken our stage 2 (see #520). We're still not sure about the details (see also #521), but disabling the new mangling scheme seems to fix things. So let's do that for now.

Alternative to #521.

Fixes #520. 