### PR TITLE
fix "cargo build --release"

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -74,6 +74,7 @@ fn build_uefi_bootloader() -> PathBuf {
         cmd.arg("--path").arg("uefi");
         println!("cargo:rerun-if-changed=uefi");
         println!("cargo:rerun-if-changed=common");
+        cmd.arg("--target-dir").arg("target/uefi_target");
     } else {
         cmd.arg("--version").arg(BOOTLOADER_VERSION);
     }
@@ -82,6 +83,7 @@ fn build_uefi_bootloader() -> PathBuf {
     cmd.arg("-Zbuild-std=core")
         .arg("-Zbuild-std-features=compiler-builtins-mem");
     cmd.arg("--root").arg(&out_dir);
+    cmd.arg("-vv");
     cmd.env_remove("RUSTFLAGS");
     cmd.env_remove("CARGO_ENCODED_RUSTFLAGS");
     let status = cmd


### PR DESCRIPTION
This bug only happend if you try to compile this library in release mode within the repo directory. This bug does not effect consumers of this library.

## How to reproduce
 1. Check out this repository
 2. `cargo build --release` (it might be necessary to run `cargo clean` if the repo was compiled in release mode before)

## What happens

After changing `build.rs` to include `cmd.arg("-vv")` in the `build_uefi_bootloader` function and also building using `cargo build -r -vv --no-default-features --features uefi` we can see that cargo hangs at the following step:

```
[bootloader 0.11.13]   Installing bootloader-x86_64-uefi v0.11.13 (/home/burkhard/programming/forks/bootloader/uefi)
[bootloader 0.11.13]     Updating crates.io index
[bootloader 0.11.13]     Blocking waiting for file lock on artifact directory
```
The issue is that the artifact directory for the uefi crate and for the bootloader crate are the same. 
1. `cargo build ` for the bootloader crate locks the artifact directory. 
2. Then at the end of the build, `build.rs` is executed which tries to run `cargo install bootloader-x86_64-uefi --path uefi .....` (the `--path` argument is only used when building localy and therefor this bug does not effect downstream consumers of this crate).
3. `cargo install` for the uefi subcrate tries to lock the same artifact directory

## Impact

As far as I can tell it is impossible to run `cargo test --release`. Otherwise this is pretty harmless.