### PR TITLE
Expose data for custom boot image creation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ impl DiskImageBuilder {
     }
 
     #[cfg(feature = "uefi")]
-    /// create a bootable fat-partition for a UEFI system.
+    /// Create a bootable FAT partition for a UEFI system.
     pub fn create_uefi_fat_partition(&self, partition_path: &Path) -> anyhow::Result<()> {
         const UEFI_BOOT_FILENAME: &str = "efi/boot/bootx64.efi";
 


### PR DESCRIPTION
Right now it is difficult to use this bootloader with more than just the basic disk-images create by this crate, e.g. it is currently not possible to create a boot-image with multiple partitions.

It can be achieved but that requires a somewhat complex build script that installs "bootloader-x86_64-uefi" or the bios variants and then creates the fat-partition by hand. 

This change exposes some functionality of `DiskImageBuilder` to make some of those things easier.
The `bootloader` crate already has a buildscript that installs the necessary uefi/bios creates and extracts those files into byte arrays. Those are now public.
I also extracted the functionality to create a boot-able FAT-partition into it's own function and marked it as pub.

The goal of this PR is not to create a fully configurable system to add partitions to the boot image, but to expose the necessary data, for consumer of this crate to build their own partitioning scheme.