### PR TITLE
(v0.9) Change `rustc-abi` in custom targets from `x86-softfloat` to `softfloat`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         KERNEL_MANIFEST: "test-kernel/Cargo.toml"
 
     - name: 'Convert Bootloader ELF to Binary'
-      run: cargo objcopy -- -I elf64-x86-64 -O binary --binary-architecture=i386:x86-64 target/x86_64-bootloader/release/bootloader target/x86_64-bootloader/release/bootloader.bin
+      run: rust-objcopy -I elf64-x86-64 -O binary --binary-architecture=i386:x86-64 target/x86_64-bootloader/release/bootloader target/x86_64-bootloader/release/bootloader.bin
 
      # install QEMU
     - name: Install QEMU (Linux)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- change `rustc-abi` in custom targets from `x86-softfloat` to `softfloat`, following [rust-lang/rust#157151](https://github.com/rust-lang/rust/pull/157151)
+
 # 0.9.34 – 2026-02-01
 
 This release is compatible with Rust nightlies starting with `nightly-2026-02-01`.

--- a/example-kernel/x86_64-example-kernel.json
+++ b/example-kernel/x86_64-example-kernel.json
@@ -12,5 +12,5 @@
     "panic-strategy": "abort",
     "disable-redzone": true,
     "features": "-mmx,-sse,+soft-float",
-    "rustc-abi": "x86-softfloat"
+    "rustc-abi": "softfloat"
   }

--- a/test-kernel/x86_64-test-kernel.json
+++ b/test-kernel/x86_64-test-kernel.json
@@ -12,5 +12,5 @@
     "panic-strategy": "abort",
     "disable-redzone": true,
     "features": "-mmx,-sse,+soft-float",
-    "rustc-abi": "x86-softfloat"
+    "rustc-abi": "softfloat"
   }

--- a/x86_64-bootloader.json
+++ b/x86_64-bootloader.json
@@ -19,5 +19,5 @@
     "panic-strategy": "abort",
     "executables": true,
     "relocation-model": "static",
-    "rustc-abi": "x86-softfloat"
+    "rustc-abi": "softfloat"
 }


### PR DESCRIPTION
The Rust PR https://github.com/rust-lang/rust/pull/157151 removed the `x86-softfloat` compatibility alias. Nightlies from
2026-07-05 onward reject `"rustc-abi": "x86-softfloat"` with:

    invalid rustc abi: 'x86-softfloat'. allowed values:
    'x86-sse2', 'powerpc-spe', 'softfloat'

Switch the three custom JSON target specs to the canonical `softfloat` value.

<i>Created with Claude Code</i>