### PR TITLE
Change `rustc-abi` in custom targets from `x86-softfloat` to `softfloat`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* change `rustc-abi` in custom targets from `x86-softfloat` to `softfloat`, following [rust-lang/rust#157151](https://github.com/rust-lang/rust/pull/157151)
+
 # 0.11.15 - 2026-02-01
 
 This release is compatible with Rust nightlies starting with `nightly-2026-02-01`.

--- a/i686-stage-3.json
+++ b/i686-stage-3.json
@@ -18,5 +18,5 @@
     "vendor": "unknown",
     "relocation-model": "static",
     "features": "+soft-float,-sse,-mmx",
-    "rustc-abi": "x86-softfloat"
+    "rustc-abi": "softfloat"
 }

--- a/x86_64-stage-4.json
+++ b/x86_64-stage-4.json
@@ -19,5 +19,5 @@
     "target-pointer-width": 64,
     "relocation-model": "static",
     "os": "none",
-    "rustc-abi": "x86-softfloat"
+    "rustc-abi": "softfloat"
 }


### PR DESCRIPTION
rust-lang/rust#157151 removed the `x86-softfloat` compatibility alias. Nightlies from
2026-07-05 onward reject `"rustc-abi": "x86-softfloat"` with:

    invalid rustc abi: 'x86-softfloat'. allowed values:
    'x86-sse2', 'powerpc-spe', 'softfloat'

Switch the stage-3 and stage-4 custom JSON target specs to the canonical `softfloat` value.

<i>Generated with Claude Code</i>
