### PR TITLE
Release 0.11.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e763eef8846b13b380f37dfecda401770b0ca4e56e95170237bd7c25c7db3582"
 
 [[package]]
+name = "const_fn"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413d67b29ef1021b4d60f4aa1e925ca031751e213832b4b1d588fae623c05c60"
+
+[[package]]
 name = "crc"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1182,12 +1188,13 @@ dependencies = [
 
 [[package]]
 name = "x86_64"
-version = "0.15.2"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f042214de98141e9c8706e8192b73f56494087cc55ebec28ce10f26c5c364ae"
+checksum = "be4ec631e1a81d50e46c35a4a00322bd076c47491b64c2fb10a7ffa89002c697"
 dependencies = [
  "bit_field",
  "bitflags 2.11.1",
+ "const_fn",
  "rustversion",
  "volatile",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader"
-version = "0.11.15"
+version = "0.11.16"
 dependencies = [
  "anyhow",
  "bootloader-boot-config",
@@ -96,22 +96,22 @@ dependencies = [
 
 [[package]]
 name = "bootloader-boot-config"
-version = "0.11.15"
+version = "0.11.16"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bootloader-x86_64-bios-boot-sector"
-version = "0.11.15"
+version = "0.11.16"
 
 [[package]]
 name = "bootloader-x86_64-bios-common"
-version = "0.11.15"
+version = "0.11.16"
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-2"
-version = "0.11.15"
+version = "0.11.16"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "byteorder",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-3"
-version = "0.11.15"
+version = "0.11.16"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "noto-sans-mono-bitmap 0.1.6",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-4"
-version = "0.11.15"
+version = "0.11.16"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-bios-common",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-common"
-version = "0.11.15"
+version = "0.11.16"
 dependencies = [
  "bootloader-boot-config",
  "bootloader_api",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-uefi"
-version = "0.11.15"
+version = "0.11.16"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-common",
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader_api"
-version = "0.11.15"
+version = "0.11.16"
 dependencies = [
  "rand",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,15 +23,15 @@ resolver = "3"
 
 [workspace.package]
 # don't forget to update `workspace.dependencies` below
-version = "0.11.15"
+version = "0.11.16"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-osdev/bootloader"
 
 [workspace.dependencies]
-bootloader_api = { version = "0.11.15", path = "api" }
-bootloader-x86_64-common = { version = "0.11.15", path = "common" }
-bootloader-boot-config = { version = "0.11.15", path = "common/config" }
-bootloader-x86_64-bios-common = { version = "0.11.15", path = "bios/common" }
+bootloader_api = { version = "0.11.16", path = "api" }
+bootloader-x86_64-common = { version = "0.11.16", path = "common" }
+bootloader-boot-config = { version = "0.11.16", path = "common/config" }
+bootloader-x86_64-bios-common = { version = "0.11.16", path = "bios/common" }
 
 [features]
 default = ["bios", "uefi"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,19 @@
 # Unreleased
 
-* change `rustc-abi` in custom targets from `x86-softfloat` to `softfloat`, following [rust-lang/rust#157151](https://github.com/rust-lang/rust/pull/157151)
+# 0.11.16 - 2026-07-07
+
+This release is compatible with Rust nightlies starting with `nightly-2026-07-06`.
+
+* change `rustc-abi` in custom targets from `x86-softfloat` to `softfloat`, following [rust-lang/rust#157151](https://github.com/rust-lang/rust/pull/157151) ([#569](https://github.com/rust-osdev/bootloader/pull/569))
+* [Fix nightly breakage (nightly-2026-05-10)](https://github.com/rust-osdev/bootloader/pull/563)
+* [Add missing `x86_64-unknown-uefi` target](https://github.com/rust-osdev/bootloader/pull/557)
+* [Bump `uart_16550` to 0.6.0](https://github.com/rust-osdev/bootloader/pull/565)
+* [Bump `critical-section`, `atomic-polyfill`, and `heapless`](https://github.com/rust-osdev/bootloader/pull/567)
+* [Speed up BIOS disk reads by merging contiguous cluster reads and skipping already-buffered data](https://github.com/rust-osdev/bootloader/pull/550)
+* [Fix FAT type detection for large FAT16 volumes](https://github.com/rust-osdev/bootloader/pull/547)
+* [Expose FAT partition creation as a separate public function](https://github.com/rust-osdev/bootloader/pull/535)
+
+**Full Changelog**: https://github.com/rust-osdev/bootloader/compare/v0.11.15...v0.11.16
 
 # 0.11.15 - 2026-02-01
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# 0.11.16 - 2026-07-07
+# 0.11.16 - 2026-07-18
 
 This release is compatible with Rust nightlies starting with `nightly-2026-07-06`.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ This release is compatible with Rust nightlies starting with `nightly-2026-07-06
 * [Speed up BIOS disk reads by merging contiguous cluster reads and skipping already-buffered data](https://github.com/rust-osdev/bootloader/pull/550)
 * [Fix FAT type detection for large FAT16 volumes](https://github.com/rust-osdev/bootloader/pull/547)
 * [Expose FAT partition creation as a separate public function](https://github.com/rust-osdev/bootloader/pull/535)
+* [uefi: bump from 0.20 to 0.38](https://github.com/rust-osdev/bootloader/pull/566)
 
 **Full Changelog**: https://github.com/rust-osdev/bootloader/compare/v0.11.15...v0.11.16
 

--- a/examples/basic/Cargo.lock
+++ b/examples/basic/Cargo.lock
@@ -1109,9 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "x86_64"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7841fa0098ceb15c567d93d3fae292c49e10a7662b4936d5f6a9728594555ba"
+checksum = "be4ec631e1a81d50e46c35a4a00322bd076c47491b64c2fb10a7ffa89002c697"
 dependencies = [
  "bit_field",
  "bitflags 2.11.0",

--- a/tests/test_kernels/Cargo.lock
+++ b/tests/test_kernels/Cargo.lock
@@ -16,7 +16,13 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bootloader_api"
-version = "0.11.15"
+version = "0.11.16"
+
+[[package]]
+name = "const_fn"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413d67b29ef1021b4d60f4aa1e925ca031751e213832b4b1d588fae623c05c60"
 
 [[package]]
 name = "rustversion"
@@ -140,12 +146,13 @@ checksum = "442887c63f2c839b346c192d047a7c87e73d0689c9157b00b53dcc27dd5ea793"
 
 [[package]]
 name = "x86_64"
-version = "0.15.2"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f042214de98141e9c8706e8192b73f56494087cc55ebec28ce10f26c5c364ae"
+checksum = "be4ec631e1a81d50e46c35a4a00322bd076c47491b64c2fb10a7ffa89002c697"
 dependencies = [
  "bit_field",
  "bitflags",
+ "const_fn",
  "rustversion",
  "volatile",
 ]


### PR DESCRIPTION
This release is compatible with Rust nightlies starting with `nightly-2026-07-06`.

* [change `rustc-abi` in custom targets from `x86-softfloat` to `softfloat`](https://github.com/rust-osdev/bootloader/pull/569), following [rust-lang/rust#157151](https://github.com/rust-lang/rust/pull/157151)
* [Fix nightly breakage (nightly-2026-05-10)](https://github.com/rust-osdev/bootloader/pull/563)
* [Add missing `x86_64-unknown-uefi` target](https://github.com/rust-osdev/bootloader/pull/557)
* [Bump `uart_16550` to 0.6.0](https://github.com/rust-osdev/bootloader/pull/565)
* [Bump `critical-section`, `atomic-polyfill`, and `heapless`](https://github.com/rust-osdev/bootloader/pull/567)
* [Speed up BIOS disk reads by merging contiguous cluster reads and skipping already-buffered data](https://github.com/rust-osdev/bootloader/pull/550)
* [Fix FAT type detection for large FAT16 volumes](https://github.com/rust-osdev/bootloader/pull/547)
* [Expose FAT partition creation as a separate public function](https://github.com/rust-osdev/bootloader/pull/535)
* [uefi: bump from 0.20 to 0.38](https://github.com/rust-osdev/bootloader/pull/566)

**Full Changelog**: https://github.com/rust-osdev/bootloader/compare/v0.11.15...v0.11.16