### PR TITLE
Fix workspace.exclude in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
     "bios/common",
     "tests/runner",
 ]
-exclude = ["examples/basic", "examples/test_framework", "tests/test_kernels/*"]
+exclude = ["examples/basic", "examples/test_framework", "tests/test_kernels/"]
 resolver = "3"
 
 [workspace.package]

--- a/tests/test_kernels/Cargo.toml
+++ b/tests/test_kernels/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "write_usable_memory",
     "fixed_kernel_address",
     "stack_address",
+    "config_file",
 ]
 
 [profile.release]


### PR DESCRIPTION
Exclude does not support globs. Instead it uses `starts_with`.

See: https://github.com/rust-lang/cargo/issues/6009