### PR TITLE
Revert `uart_16550` version bump to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
  "rsdp",
  "serde-json-core",
  "usize_conversions",
- "x86_64",
+ "x86_64 0.15.5",
 ]
 
 [[package]]
@@ -154,9 +154,9 @@ dependencies = [
  "rand_hc",
  "raw-cpuid",
  "spinning_top",
- "uart_16550",
+ "uart_16550 0.3.2",
  "usize_conversions",
- "x86_64",
+ "x86_64 0.15.5",
  "xmas-elf",
 ]
 
@@ -170,7 +170,7 @@ dependencies = [
  "log",
  "serde-json-core",
  "uefi",
- "x86_64",
+ "x86_64 0.15.5",
 ]
 
 [[package]]
@@ -775,8 +775,8 @@ name = "test_kernel_config_file"
 version = "0.1.0"
 dependencies = [
  "bootloader_api",
- "uart_16550",
- "x86_64",
+ "uart_16550 0.2.18",
+ "x86_64 0.15.5",
 ]
 
 [[package]]
@@ -784,8 +784,8 @@ name = "test_kernel_default_settings"
 version = "0.1.0"
 dependencies = [
  "bootloader_api",
- "uart_16550",
- "x86_64",
+ "uart_16550 0.2.18",
+ "x86_64 0.15.5",
 ]
 
 [[package]]
@@ -793,8 +793,8 @@ name = "test_kernel_fixed_kernel_address"
 version = "0.1.0"
 dependencies = [
  "bootloader_api",
- "uart_16550",
- "x86_64",
+ "uart_16550 0.2.18",
+ "x86_64 0.15.5",
 ]
 
 [[package]]
@@ -802,8 +802,8 @@ name = "test_kernel_higher_half"
 version = "0.1.0"
 dependencies = [
  "bootloader_api",
- "uart_16550",
- "x86_64",
+ "uart_16550 0.2.18",
+ "x86_64 0.15.5",
 ]
 
 [[package]]
@@ -811,8 +811,8 @@ name = "test_kernel_lower_memory_free"
 version = "0.1.0"
 dependencies = [
  "bootloader_api",
- "uart_16550",
- "x86_64",
+ "uart_16550 0.2.18",
+ "x86_64 0.15.5",
 ]
 
 [[package]]
@@ -820,8 +820,8 @@ name = "test_kernel_map_phys_mem"
 version = "0.1.0"
 dependencies = [
  "bootloader_api",
- "uart_16550",
- "x86_64",
+ "uart_16550 0.2.18",
+ "x86_64 0.15.5",
 ]
 
 [[package]]
@@ -829,8 +829,8 @@ name = "test_kernel_min_stack"
 version = "0.1.0"
 dependencies = [
  "bootloader_api",
- "uart_16550",
- "x86_64",
+ "uart_16550 0.2.18",
+ "x86_64 0.15.5",
 ]
 
 [[package]]
@@ -838,8 +838,8 @@ name = "test_kernel_pie"
 version = "0.1.0"
 dependencies = [
  "bootloader_api",
- "uart_16550",
- "x86_64",
+ "uart_16550 0.2.18",
+ "x86_64 0.15.5",
 ]
 
 [[package]]
@@ -847,8 +847,8 @@ name = "test_kernel_ramdisk"
 version = "0.1.0"
 dependencies = [
  "bootloader_api",
- "uart_16550",
- "x86_64",
+ "uart_16550 0.2.18",
+ "x86_64 0.15.5",
 ]
 
 [[package]]
@@ -856,8 +856,8 @@ name = "test_kernel_stack_address"
 version = "0.1.0"
 dependencies = [
  "bootloader_api",
- "uart_16550",
- "x86_64",
+ "uart_16550 0.2.18",
+ "x86_64 0.15.5",
 ]
 
 [[package]]
@@ -865,8 +865,8 @@ name = "test_kernel_write_usable_memory"
 version = "0.1.0"
 dependencies = [
  "bootloader_api",
- "uart_16550",
- "x86_64",
+ "uart_16550 0.2.18",
+ "x86_64 0.15.5",
 ]
 
 [[package]]
@@ -891,11 +891,24 @@ dependencies = [
 
 [[package]]
 name = "uart_16550"
-version = "0.6.0"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ee77075ecbc5e1c9b1236d03ff013dd77c7bb06da181c5c44f1f39b6cf3ff2"
+checksum = "b074eb9300ad949edd74c529c0e8d451625af71bb948e6b65fe69f72dc1363d9"
+dependencies = [
+ "bitflags 1.3.2",
+ "rustversion",
+ "x86_64 0.14.13",
+]
+
+[[package]]
+name = "uart_16550"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e492212ac378a5e00da953718dafb1340d9fbaf4f27d6f3c5cab03d931d1c049"
 dependencies = [
  "bitflags 2.11.1",
+ "rustversion",
+ "x86",
 ]
 
 [[package]]
@@ -1184,6 +1197,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x86"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2781db97787217ad2a2845c396a5efe286f87467a5810836db6d74926e94a385"
+dependencies = [
+ "bit_field",
+ "bitflags 1.3.2",
+ "raw-cpuid",
+]
+
+[[package]]
+name = "x86_64"
+version = "0.14.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c101112411baafbb4bf8d33e4c4a80ab5b02d74d2612331c61e8192fc9710491"
+dependencies = [
+ "bit_field",
+ "bitflags 2.11.1",
+ "rustversion",
+ "volatile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ members = [
     "tests/runner",
 ]
 exclude = ["examples/basic", "examples/test_framework", "tests/test_kernels/"]
-resolver = "3"
 
 [workspace.package]
 # don't forget to update `workspace.dependencies` below

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -19,7 +19,7 @@ xmas-elf = "0.8.0"
 raw-cpuid = "10.2.0"
 rand = { version = "0.8.6", default-features = false }
 rand_hc = "0.3.1"
-uart_16550 = "0.6.0"
+uart_16550 = "0.3.2"
 log = "0.4.17"
 
 [dependencies.noto-sans-mono-bitmap]

--- a/common/src/serial.rs
+++ b/common/src/serial.rs
@@ -1,10 +1,7 @@
 use core::fmt;
-use uart_16550::backend::PioBackend;
 
-// TODO this type can be replaced with Uart16550Tty but using it currently panics
-// in the new constructor.
 pub struct SerialPort {
-    port: uart_16550::Uart16550<PioBackend>,
+    port: uart_16550::SerialPort,
 }
 
 impl SerialPort {
@@ -12,10 +9,8 @@ impl SerialPort {
     ///
     /// unsafe because this function must only be called once
     pub unsafe fn init() -> Self {
-        let mut port =
-            unsafe { uart_16550::Uart16550::new_port(0x3F8) }.expect("should be valid port");
-        port.init(uart_16550::Config::default())
-            .expect("should init successfully");
+        let mut port = unsafe { uart_16550::SerialPort::new(0x3F8) };
+        port.init();
         Self { port }
     }
 }
@@ -24,8 +19,8 @@ impl fmt::Write for SerialPort {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         for char in s.bytes() {
             match char {
-                b'\n' => self.port.send_bytes_exact(b"\r\n"),
-                byte => self.port.send_bytes_exact(&[byte]),
+                b'\n' => self.port.write_str("\r\n").unwrap(),
+                byte => self.port.send(byte),
             }
         }
         Ok(())

--- a/examples/basic/Cargo.lock
+++ b/examples/basic/Cargo.lock
@@ -472,6 +472,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
+name = "raw-cpuid"
+version = "10.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,11 +709,13 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uart_16550"
-version = "0.6.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ee77075ecbc5e1c9b1236d03ff013dd77c7bb06da181c5c44f1f39b6cf3ff2"
+checksum = "94d293f51425981fdb1b766beae254dbb711a17e8c4b549dc69b9b7ee0d478d5"
 dependencies = [
  "bitflags 2.13.1",
+ "rustversion",
+ "x86",
 ]
 
 [[package]]
@@ -919,12 +930,111 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x86"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2781db97787217ad2a2845c396a5efe286f87467a5810836db6d74926e94a385"
+dependencies = [
+ "bit_field",
+ "bitflags 1.3.2",
+ "raw-cpuid",
 ]
 
 [[package]]

--- a/examples/basic/kernel/Cargo.toml
+++ b/examples/basic/kernel/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 
 [dependencies]
 bootloader_api = "0.11.12"
-uart_16550 = "0.6.0"
+uart_16550 = "0.4.0"
 x86_64 = "0.15.2"

--- a/examples/basic/kernel/src/main.rs
+++ b/examples/basic/kernel/src/main.rs
@@ -3,8 +3,6 @@
 
 use bootloader_api::{BootInfo, entry_point};
 use core::fmt::Write;
-use uart_16550::backend::PioBackend;
-use uart_16550::{Config, Uart16550Tty};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
@@ -26,9 +24,10 @@ pub fn exit_qemu(exit_code: QemuExitCode) -> ! {
     }
 }
 
-pub fn serial() -> Uart16550Tty<PioBackend> {
-    unsafe { Uart16550Tty::new_port(0x3F8, Config::default()) }
-        .expect("should initialize serial device from valid config and valid port")
+pub fn serial() -> uart_16550::SerialPort {
+    let mut port = unsafe { uart_16550::SerialPort::new(0x3F8) };
+    port.init();
+    port
 }
 
 entry_point!(kernel_main);

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -62,8 +62,8 @@ fn main() {
     let mut child = cmd.spawn().expect("failed to start qemu-system-x86_64");
     let status = child.wait().expect("failed to wait on qemu");
     match status.code().unwrap_or(1) {
-        0x10 => 0, // success
-        0x11 => 1, // failure
-        _ => 2,    // unknown fault
+        0x10 => 0,  // success
+        0x11 => 1,  // failure
+        _    => 2,  // unknown fault
     };
 }

--- a/tests/test_kernels/Cargo.lock
+++ b/tests/test_kernels/Cargo.lock
@@ -10,19 +10,19 @@ checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bootloader_api"
 version = "0.11.16"
-
-[[package]]
-name = "const_fn"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413d67b29ef1021b4d60f4aa1e925ca031751e213832b4b1d588fae623c05c60"
 
 [[package]]
 name = "rustversion"
@@ -31,12 +31,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
+name = "test_kernel_config_file"
+version = "0.1.0"
+dependencies = [
+ "bootloader_api",
+ "uart_16550",
+ "x86_64 0.15.2",
+]
+
+[[package]]
 name = "test_kernel_default_settings"
 version = "0.1.0"
 dependencies = [
  "bootloader_api",
  "uart_16550",
- "x86_64",
+ "x86_64 0.15.2",
 ]
 
 [[package]]
@@ -45,7 +54,7 @@ version = "0.1.0"
 dependencies = [
  "bootloader_api",
  "uart_16550",
- "x86_64",
+ "x86_64 0.15.2",
 ]
 
 [[package]]
@@ -54,7 +63,7 @@ version = "0.1.0"
 dependencies = [
  "bootloader_api",
  "uart_16550",
- "x86_64",
+ "x86_64 0.15.2",
 ]
 
 [[package]]
@@ -63,7 +72,7 @@ version = "0.1.0"
 dependencies = [
  "bootloader_api",
  "uart_16550",
- "x86_64",
+ "x86_64 0.15.2",
 ]
 
 [[package]]
@@ -72,7 +81,7 @@ version = "0.1.0"
 dependencies = [
  "bootloader_api",
  "uart_16550",
- "x86_64",
+ "x86_64 0.15.2",
 ]
 
 [[package]]
@@ -81,7 +90,7 @@ version = "0.1.0"
 dependencies = [
  "bootloader_api",
  "uart_16550",
- "x86_64",
+ "x86_64 0.15.2",
 ]
 
 [[package]]
@@ -90,7 +99,7 @@ version = "0.1.0"
 dependencies = [
  "bootloader_api",
  "uart_16550",
- "x86_64",
+ "x86_64 0.15.2",
 ]
 
 [[package]]
@@ -99,7 +108,7 @@ version = "0.1.0"
 dependencies = [
  "bootloader_api",
  "uart_16550",
- "x86_64",
+ "x86_64 0.15.2",
 ]
 
 [[package]]
@@ -108,7 +117,7 @@ version = "0.1.0"
 dependencies = [
  "bootloader_api",
  "uart_16550",
- "x86_64",
+ "x86_64 0.15.2",
 ]
 
 [[package]]
@@ -117,7 +126,7 @@ version = "0.1.0"
 dependencies = [
  "bootloader_api",
  "uart_16550",
- "x86_64",
+ "x86_64 0.15.2",
 ]
 
 [[package]]
@@ -126,16 +135,18 @@ version = "0.1.0"
 dependencies = [
  "bootloader_api",
  "uart_16550",
- "x86_64",
+ "x86_64 0.15.2",
 ]
 
 [[package]]
 name = "uart_16550"
-version = "0.6.0"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ee77075ecbc5e1c9b1236d03ff013dd77c7bb06da181c5c44f1f39b6cf3ff2"
+checksum = "614ff2a87880d4bd4374722268598a970bbad05ced8bf630439417347254ab2e"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
+ "rustversion",
+ "x86_64 0.14.13",
 ]
 
 [[package]]
@@ -146,13 +157,24 @@ checksum = "442887c63f2c839b346c192d047a7c87e73d0689c9157b00b53dcc27dd5ea793"
 
 [[package]]
 name = "x86_64"
-version = "0.15.5"
+version = "0.14.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4ec631e1a81d50e46c35a4a00322bd076c47491b64c2fb10a7ffa89002c697"
+checksum = "c101112411baafbb4bf8d33e4c4a80ab5b02d74d2612331c61e8192fc9710491"
 dependencies = [
  "bit_field",
- "bitflags",
- "const_fn",
+ "bitflags 2.8.0",
+ "rustversion",
+ "volatile",
+]
+
+[[package]]
+name = "x86_64"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f042214de98141e9c8706e8192b73f56494087cc55ebec28ce10f26c5c364ae"
+dependencies = [
+ "bit_field",
+ "bitflags 2.8.0",
  "rustversion",
  "volatile",
 ]

--- a/tests/test_kernels/config_file/Cargo.toml
+++ b/tests/test_kernels/config_file/Cargo.toml
@@ -9,4 +9,4 @@ bootloader_api = { path = "../../../api" }
 x86_64 = { version = "0.15.2", default-features = false, features = [
     "instructions",
 ] }
-uart_16550 = "0.6.0"
+uart_16550 = "0.2.10"

--- a/tests/test_kernels/config_file/src/lib.rs
+++ b/tests/test_kernels/config_file/src/lib.rs
@@ -1,8 +1,5 @@
 #![no_std]
 
-use uart_16550::backend::PioBackend;
-use uart_16550::{Config, Uart16550Tty};
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
 pub enum QemuExitCode {
@@ -23,7 +20,8 @@ pub fn exit_qemu(exit_code: QemuExitCode) -> ! {
     }
 }
 
-pub fn serial() -> Uart16550Tty<PioBackend> {
-    unsafe { Uart16550Tty::new_port(0x3F8, Config::default()) }
-        .expect("should initialize serial device from valid config and valid port")
+pub fn serial() -> uart_16550::SerialPort {
+    let mut port = unsafe { uart_16550::SerialPort::new(0x3F8) };
+    port.init();
+    port
 }

--- a/tests/test_kernels/default_settings/Cargo.toml
+++ b/tests/test_kernels/default_settings/Cargo.toml
@@ -9,4 +9,4 @@ bootloader_api = { path = "../../../api" }
 x86_64 = { version = "0.15.2", default-features = false, features = [
     "instructions",
 ] }
-uart_16550 = "0.6.0"
+uart_16550 = "0.2.10"

--- a/tests/test_kernels/default_settings/src/lib.rs
+++ b/tests/test_kernels/default_settings/src/lib.rs
@@ -1,8 +1,5 @@
 #![no_std]
 
-use uart_16550::backend::PioBackend;
-use uart_16550::{Config, Uart16550Tty};
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
 pub enum QemuExitCode {
@@ -23,7 +20,8 @@ pub fn exit_qemu(exit_code: QemuExitCode) -> ! {
     }
 }
 
-pub fn serial() -> Uart16550Tty<PioBackend> {
-    unsafe { Uart16550Tty::new_port(0x3F8, Config::default()) }
-        .expect("should initialize serial device from valid config and valid port")
+pub fn serial() -> uart_16550::SerialPort {
+    let mut port = unsafe { uart_16550::SerialPort::new(0x3F8) };
+    port.init();
+    port
 }

--- a/tests/test_kernels/fixed_kernel_address/Cargo.toml
+++ b/tests/test_kernels/fixed_kernel_address/Cargo.toml
@@ -8,4 +8,4 @@ bootloader_api = { path = "../../../api" }
 x86_64 = { version = "0.15.2", default-features = false, features = [
     "instructions",
 ] }
-uart_16550 = "0.6.0"
+uart_16550 = "0.2.10"

--- a/tests/test_kernels/fixed_kernel_address/src/lib.rs
+++ b/tests/test_kernels/fixed_kernel_address/src/lib.rs
@@ -1,8 +1,6 @@
 #![no_std]
 
 use bootloader_api::{BootloaderConfig, config::Mapping};
-use uart_16550::backend::PioBackend;
-use uart_16550::{Config, Uart16550Tty};
 
 pub const KERNEL_ADDR: u64 = 0x1987_6543_0000;
 
@@ -32,7 +30,8 @@ pub fn exit_qemu(exit_code: QemuExitCode) -> ! {
     }
 }
 
-pub fn serial() -> Uart16550Tty<PioBackend> {
-    unsafe { Uart16550Tty::new_port(0x3F8, Config::default()) }
-        .expect("should initialize serial device from valid config and valid port")
+pub fn serial() -> uart_16550::SerialPort {
+    let mut port = unsafe { uart_16550::SerialPort::new(0x3F8) };
+    port.init();
+    port
 }

--- a/tests/test_kernels/higher_half/Cargo.toml
+++ b/tests/test_kernels/higher_half/Cargo.toml
@@ -11,6 +11,6 @@ bootloader_api = { path = "../../../api" }
 x86_64 = { version = "0.15.2", default-features = false, features = [
     "instructions",
 ] }
-uart_16550 = "0.6.0"
+uart_16550 = "0.2.10"
 
 # set to higher half through profile.test.rustflags key in top-level Cargo.toml

--- a/tests/test_kernels/higher_half/src/lib.rs
+++ b/tests/test_kernels/higher_half/src/lib.rs
@@ -1,8 +1,6 @@
 #![no_std]
 
 use bootloader_api::BootloaderConfig;
-use uart_16550::backend::PioBackend;
-use uart_16550::{Config, Uart16550Tty};
 
 pub const BOOTLOADER_CONFIG: BootloaderConfig = {
     let mut config = BootloaderConfig::new_default();
@@ -30,7 +28,8 @@ pub fn exit_qemu(exit_code: QemuExitCode) -> ! {
     }
 }
 
-pub fn serial() -> Uart16550Tty<PioBackend> {
-    unsafe { Uart16550Tty::new_port(0x3F8, Config::default()) }
-        .expect("should initialize serial device from valid config and valid port")
+pub fn serial() -> uart_16550::SerialPort {
+    let mut port = unsafe { uart_16550::SerialPort::new(0x3F8) };
+    port.init();
+    port
 }

--- a/tests/test_kernels/lower_memory_free/Cargo.toml
+++ b/tests/test_kernels/lower_memory_free/Cargo.toml
@@ -8,4 +8,4 @@ bootloader_api = { path = "../../../api" }
 x86_64 = { version = "0.15.2", default-features = false, features = [
     "instructions",
 ] }
-uart_16550 = "0.6.0"
+uart_16550 = "0.2.10"

--- a/tests/test_kernels/lower_memory_free/src/lib.rs
+++ b/tests/test_kernels/lower_memory_free/src/lib.rs
@@ -1,8 +1,5 @@
 #![no_std]
 
-use uart_16550::backend::PioBackend;
-use uart_16550::{Config, Uart16550Tty};
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
 pub enum QemuExitCode {
@@ -23,7 +20,8 @@ pub fn exit_qemu(exit_code: QemuExitCode) -> ! {
     }
 }
 
-pub fn serial() -> Uart16550Tty<PioBackend> {
-    unsafe { Uart16550Tty::new_port(0x3F8, Config::default()) }
-        .expect("should initialize serial device from valid config and valid port")
+pub fn serial() -> uart_16550::SerialPort {
+    let mut port = unsafe { uart_16550::SerialPort::new(0x3F8) };
+    port.init();
+    port
 }

--- a/tests/test_kernels/lto/Cargo.toml
+++ b/tests/test_kernels/lto/Cargo.toml
@@ -9,4 +9,4 @@ bootloader_api = { path = "../../../api" }
 x86_64 = { version = "0.15.2", default-features = false, features = [
     "instructions",
 ] }
-uart_16550 = "0.6.0"
+uart_16550 = "0.2.10"

--- a/tests/test_kernels/lto/src/lib.rs
+++ b/tests/test_kernels/lto/src/lib.rs
@@ -1,8 +1,5 @@
 #![no_std]
 
-use uart_16550::backend::PioBackend;
-use uart_16550::{Config, Uart16550Tty};
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
 pub enum QemuExitCode {
@@ -23,7 +20,8 @@ pub fn exit_qemu(exit_code: QemuExitCode) -> ! {
     }
 }
 
-pub fn serial() -> Uart16550Tty<PioBackend> {
-    unsafe { Uart16550Tty::new_port(0x3F8, Config::default()) }
-        .expect("should initialize serial device from valid config and valid port")
+pub fn serial() -> uart_16550::SerialPort {
+    let mut port = unsafe { uart_16550::SerialPort::new(0x3F8) };
+    port.init();
+    port
 }

--- a/tests/test_kernels/map_phys_mem/Cargo.toml
+++ b/tests/test_kernels/map_phys_mem/Cargo.toml
@@ -9,4 +9,4 @@ bootloader_api = { path = "../../../api" }
 x86_64 = { version = "0.15.2", default-features = false, features = [
     "instructions",
 ] }
-uart_16550 = "0.6.0"
+uart_16550 = "0.2.10"

--- a/tests/test_kernels/map_phys_mem/src/lib.rs
+++ b/tests/test_kernels/map_phys_mem/src/lib.rs
@@ -1,8 +1,6 @@
 #![no_std]
 
 use bootloader_api::{BootloaderConfig, config::Mapping};
-use uart_16550::backend::PioBackend;
-use uart_16550::{Config, Uart16550Tty};
 
 pub const BOOTLOADER_CONFIG: BootloaderConfig = {
     let mut config = BootloaderConfig::new_default();
@@ -30,7 +28,8 @@ pub fn exit_qemu(exit_code: QemuExitCode) -> ! {
     }
 }
 
-pub fn serial() -> Uart16550Tty<PioBackend> {
-    unsafe { Uart16550Tty::new_port(0x3F8, Config::default()) }
-        .expect("should initialize serial device from valid config and valid port")
+pub fn serial() -> uart_16550::SerialPort {
+    let mut port = unsafe { uart_16550::SerialPort::new(0x3F8) };
+    port.init();
+    port
 }

--- a/tests/test_kernels/min_stack/Cargo.toml
+++ b/tests/test_kernels/min_stack/Cargo.toml
@@ -9,4 +9,4 @@ bootloader_api = { path = "../../../api" }
 x86_64 = { version = "0.15.2", default-features = false, features = [
     "instructions",
 ] }
-uart_16550 = "0.6.0"
+uart_16550 = "0.2.10"

--- a/tests/test_kernels/min_stack/src/lib.rs
+++ b/tests/test_kernels/min_stack/src/lib.rs
@@ -1,8 +1,5 @@
 #![no_std]
 
-use uart_16550::backend::PioBackend;
-use uart_16550::{Config, Uart16550Tty};
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
 pub enum QemuExitCode {
@@ -23,7 +20,8 @@ pub fn exit_qemu(exit_code: QemuExitCode) -> ! {
     }
 }
 
-pub fn serial() -> Uart16550Tty<PioBackend> {
-    unsafe { Uart16550Tty::new_port(0x3F8, Config::default()) }
-        .expect("should initialize serial device from valid config and valid port")
+pub fn serial() -> uart_16550::SerialPort {
+    let mut port = unsafe { uart_16550::SerialPort::new(0x3F8) };
+    port.init();
+    port
 }

--- a/tests/test_kernels/pie/Cargo.toml
+++ b/tests/test_kernels/pie/Cargo.toml
@@ -9,4 +9,4 @@ bootloader_api = { path = "../../../api" }
 x86_64 = { version = "0.15.2", default-features = false, features = [
     "instructions",
 ] }
-uart_16550 = "0.6.0"
+uart_16550 = "0.2.10"

--- a/tests/test_kernels/pie/src/lib.rs
+++ b/tests/test_kernels/pie/src/lib.rs
@@ -1,8 +1,5 @@
 #![no_std]
 
-use uart_16550::backend::PioBackend;
-use uart_16550::{Config, Uart16550Tty};
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
 pub enum QemuExitCode {
@@ -23,7 +20,8 @@ pub fn exit_qemu(exit_code: QemuExitCode) -> ! {
     }
 }
 
-pub fn serial() -> Uart16550Tty<PioBackend> {
-    unsafe { Uart16550Tty::new_port(0x3F8, Config::default()) }
-        .expect("should initialize serial device from valid config and valid port")
+pub fn serial() -> uart_16550::SerialPort {
+    let mut port = unsafe { uart_16550::SerialPort::new(0x3F8) };
+    port.init();
+    port
 }

--- a/tests/test_kernels/ramdisk/Cargo.toml
+++ b/tests/test_kernels/ramdisk/Cargo.toml
@@ -9,4 +9,4 @@ bootloader_api = { path = "../../../api" }
 x86_64 = { version = "0.15.2", default-features = false, features = [
     "instructions",
 ] }
-uart_16550 = "0.6.0"
+uart_16550 = "0.2.10"

--- a/tests/test_kernels/ramdisk/src/lib.rs
+++ b/tests/test_kernels/ramdisk/src/lib.rs
@@ -1,8 +1,5 @@
 #![no_std]
 
-use uart_16550::backend::PioBackend;
-use uart_16550::{Config, Uart16550Tty};
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
 pub enum QemuExitCode {
@@ -25,7 +22,8 @@ pub fn exit_qemu(exit_code: QemuExitCode) -> ! {
     }
 }
 
-pub fn serial() -> Uart16550Tty<PioBackend> {
-    unsafe { Uart16550Tty::new_port(0x3F8, Config::default()) }
-        .expect("should initialize serial device from valid config and valid port")
+pub fn serial() -> uart_16550::SerialPort {
+    let mut port = unsafe { uart_16550::SerialPort::new(0x3F8) };
+    port.init();
+    port
 }

--- a/tests/test_kernels/stack_address/Cargo.toml
+++ b/tests/test_kernels/stack_address/Cargo.toml
@@ -8,4 +8,4 @@ bootloader_api = { path = "../../../api" }
 x86_64 = { version = "0.15.2", default-features = false, features = [
     "instructions",
 ] }
-uart_16550 = "0.6.0"
+uart_16550 = "0.2.10"

--- a/tests/test_kernels/stack_address/src/lib.rs
+++ b/tests/test_kernels/stack_address/src/lib.rs
@@ -1,8 +1,6 @@
 #![no_std]
 
 use bootloader_api::{BootloaderConfig, config::Mapping};
-use uart_16550::backend::PioBackend;
-use uart_16550::{Config, Uart16550Tty};
 
 pub const KERNEL_ADDR: u64 = 0x1987_6543_0000;
 
@@ -32,7 +30,8 @@ pub fn exit_qemu(exit_code: QemuExitCode) -> ! {
     }
 }
 
-pub fn serial() -> Uart16550Tty<PioBackend> {
-    unsafe { Uart16550Tty::new_port(0x3F8, Config::default()) }
-        .expect("should initialize serial device from valid config and valid port")
+pub fn serial() -> uart_16550::SerialPort {
+    let mut port = unsafe { uart_16550::SerialPort::new(0x3F8) };
+    port.init();
+    port
 }

--- a/tests/test_kernels/write_usable_memory/Cargo.toml
+++ b/tests/test_kernels/write_usable_memory/Cargo.toml
@@ -8,4 +8,4 @@ bootloader_api = { path = "../../../api" }
 x86_64 = { version = "0.15.2", default-features = false, features = [
     "instructions",
 ] }
-uart_16550 = "0.6.0"
+uart_16550 = "0.2.10"

--- a/tests/test_kernels/write_usable_memory/src/lib.rs
+++ b/tests/test_kernels/write_usable_memory/src/lib.rs
@@ -1,8 +1,5 @@
 #![no_std]
 
-use uart_16550::backend::PioBackend;
-use uart_16550::{Config, Uart16550Tty};
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
 pub enum QemuExitCode {
@@ -23,7 +20,8 @@ pub fn exit_qemu(exit_code: QemuExitCode) -> ! {
     }
 }
 
-pub fn serial() -> Uart16550Tty<PioBackend> {
-    unsafe { Uart16550Tty::new_port(0x3F8, Config::default()) }
-        .expect("should initialize serial device from valid config and valid port")
+pub fn serial() -> uart_16550::SerialPort {
+    let mut port = unsafe { uart_16550::SerialPort::new(0x3F8) };
+    port.init();
+    port
 }


### PR DESCRIPTION
This reverts commit 6e925289cf029ee71da3bfb6db3a8cb78fa20a5f of PR #565.

The reason for the revert is that uart_16550 v0.6.0 leads to hangs when no serial is connected or when no CTS line is connected. See https://github.com/rust-osdev/bootloader/issues/573#issuecomment-5058229259, https://github.com/rust-osdev/bootloader/pull/565#issuecomment-5058317327, and https://github.com/rust-osdev/uart_16550/issues/65.
