### PR TITLE
Release v0.11.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader"
-version = "0.11.16"
+version = "0.11.17"
 dependencies = [
  "anyhow",
  "bootloader-boot-config",
@@ -96,22 +96,22 @@ dependencies = [
 
 [[package]]
 name = "bootloader-boot-config"
-version = "0.11.16"
+version = "0.11.17"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bootloader-x86_64-bios-boot-sector"
-version = "0.11.16"
+version = "0.11.17"
 
 [[package]]
 name = "bootloader-x86_64-bios-common"
-version = "0.11.16"
+version = "0.11.17"
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-2"
-version = "0.11.16"
+version = "0.11.17"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "byteorder",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-3"
-version = "0.11.16"
+version = "0.11.17"
 dependencies = [
  "bootloader-x86_64-bios-common",
  "noto-sans-mono-bitmap 0.1.6",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-bios-stage-4"
-version = "0.11.16"
+version = "0.11.17"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-bios-common",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-common"
-version = "0.11.16"
+version = "0.11.17"
 dependencies = [
  "bootloader-boot-config",
  "bootloader_api",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader-x86_64-uefi"
-version = "0.11.16"
+version = "0.11.17"
 dependencies = [
  "bootloader-boot-config",
  "bootloader-x86_64-common",
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "bootloader_api"
-version = "0.11.16"
+version = "0.11.17"
 dependencies = [
  "rand",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,15 +22,15 @@ exclude = ["examples/basic", "examples/test_framework", "tests/test_kernels/"]
 
 [workspace.package]
 # don't forget to update `workspace.dependencies` below
-version = "0.11.16"
+version = "0.11.17"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-osdev/bootloader"
 
 [workspace.dependencies]
-bootloader_api = { version = "0.11.16", path = "api" }
-bootloader-x86_64-common = { version = "0.11.16", path = "common" }
-bootloader-boot-config = { version = "0.11.16", path = "common/config" }
-bootloader-x86_64-bios-common = { version = "0.11.16", path = "bios/common" }
+bootloader_api = { version = "0.11.17", path = "api" }
+bootloader-x86_64-common = { version = "0.11.17", path = "common" }
+bootloader-boot-config = { version = "0.11.17", path = "common/config" }
+bootloader-x86_64-bios-common = { version = "0.11.17", path = "bios/common" }
 
 [features]
 default = ["bios", "uefi"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,12 @@
 # Unreleased
 
+# 0.11.17 - 2026-07-27
+
+* [Revert `uart_16550` version bump to 0.6.0](https://github.com/rust-osdev/bootloader/pull/575)
+* [Fix `workspace.exclude` in `Cargo.toml`](https://github.com/rust-osdev/bootloader/pull/571)
+
+**Full Changelog**: https://github.com/rust-osdev/bootloader/compare/v0.11.16...v0.11.17
+
 # 0.11.16 - 2026-07-18
 
 This release is compatible with Rust nightlies starting with `nightly-2026-07-06`.

--- a/tests/test_kernels/Cargo.lock
+++ b/tests/test_kernels/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bootloader_api"
-version = "0.11.16"
+version = "0.11.17"
 
 [[package]]
 name = "rustversion"


### PR DESCRIPTION
* [Revert `uart_16550` version bump to 0.6.0](https://github.com/rust-osdev/bootloader/pull/575)
* [Fix `workspace.exclude` in `Cargo.toml`](https://github.com/rust-osdev/bootloader/pull/571)